### PR TITLE
fix(prerecorded/live): align named_entity_recognition with API response shape

### DIFF
--- a/e2e/e2e-node-cjs/test/live_v2_session.test.cjs
+++ b/e2e/e2e-node-cjs/test/live_v2_session.test.cjs
@@ -49,3 +49,72 @@ test('split infinity', async () => {
     /^\ssplit infinity\p{P}*$/iu
   )
 })
+
+test('named entity recognition: anna-and-sasha yields Sasha as NAME_GIVEN', async () => {
+  const audioFile = 'anna-and-sasha-16000.wav'
+  const audioData = parseAudioFile(audioFile)
+
+  /** @type {(import('@gladiaio/sdk').LiveV2TranscriptMessage)[]} */
+  const transcripts = []
+  /** @type {(import('@gladiaio/sdk').LiveV2NamedEntityRecognitionMessage)[]} */
+  const nerMessages = []
+  const liveSession = new GladiaClient().liveV2().startSession({
+    ...audioData.audioConfig,
+    language_config: {
+      languages: ['en'],
+    },
+    realtime_processing: {
+      named_entity_recognition: true,
+    },
+    messages_config: {
+      receive_final_transcripts: true,
+      receive_realtime_processing_events: true,
+    },
+  })
+  assert.equal(liveSession.status, 'starting')
+
+  liveSession.on('message', (message) => {
+    if (message.type === 'transcript') {
+      transcripts.push(message)
+    } else if (message.type === 'named_entity_recognition') {
+      nerMessages.push(message)
+    }
+  })
+  liveSession.once('error', (error) => {
+    console.error(error)
+  })
+
+  const endPromise = new Promise((resolve) => {
+    liveSession.once('ended', () => {
+      resolve()
+    })
+  })
+
+  await sendAudioFile(audioData, liveSession, 50)
+  liveSession.stopRecording()
+  assert.equal(liveSession.status, 'ending')
+
+  await endPromise
+  assert.equal(liveSession.status, 'ended')
+
+  const full = transcripts
+    .map((t) => t.data.utterance.text)
+    .join(' ')
+    .toLowerCase()
+  assert(full.includes('sasha'), 'expected transcript to contain sasha')
+
+  /** @type {import('@gladiaio/sdk').LiveV2NamedEntityRecognitionResult[]} */
+  const rawResults = []
+  for (const msg of nerMessages) {
+    if (msg.data?.results) {
+      rawResults.push(...msg.data.results)
+    }
+  }
+  const sashaAsGiven = rawResults.filter(
+    (r) => r.text.toLowerCase().includes('sasha') && r.entity_type.toUpperCase() === 'NAME_GIVEN'
+  )
+  assert(
+    sashaAsGiven.length > 0,
+    `expected NAME_GIVEN entity for Sasha, got ${JSON.stringify(rawResults.map((r) => [r.entity_type, r.text]))}`
+  )
+})

--- a/e2e/e2e-node-cjs/test/prerecorded_v2_async.test.cjs
+++ b/e2e/e2e-node-cjs/test/prerecorded_v2_async.test.cjs
@@ -168,6 +168,34 @@ test('transcribe: file + options as plain object (e.g. sentiment_analysis) → r
   assert(result.result.transcription != null)
 })
 
+test('transcribe: named entity recognition detects Sasha as NAME_GIVEN (anna-and-sasha audio)', async () => {
+  const client = new GladiaClient().preRecordedV2()
+  const options = {
+    language_config: { languages: ['en'] },
+    named_entity_recognition: true,
+  }
+  const audioPathSasha = getDataFile('anna-and-sasha-16000.wav')
+  const result = await client.transcribe(audioPathSasha, options, {
+    interval: POLL_INTERVAL_MS,
+    timeout: POLL_TIMEOUT_MS,
+  })
+  assert.strictEqual(result.status, 'done')
+  assert(result.result != null)
+  const full = (result.result.transcription?.full_transcript || '').toLowerCase()
+  assert(full.includes('sasha'), 'expected transcript to contain sasha')
+  const ner = result.result.named_entity_recognition
+  assert(ner != null)
+  assert.strictEqual(ner.success, true, ner.error ? JSON.stringify(ner.error) : '')
+  const rawResults = ner.results ?? []
+  const sashaAsGivenName = rawResults.filter(
+    (r) => r.text.toLowerCase().includes('sasha') && r.entity_type.toUpperCase() === 'NAME_GIVEN'
+  )
+  assert(
+    sashaAsGivenName.length > 0,
+    `expected NAME_GIVEN entity for Sasha, got ${JSON.stringify(rawResults.map((r) => [r.entity_type, r.text]))}`
+  )
+})
+
 test('transcribe: URL → direct create + poll (no upload) returns done with non-empty transcript', async () => {
   const client = new GladiaClient().preRecordedV2()
   const options = {

--- a/e2e/e2e-node-esm/test/live_v2_session.test.ts
+++ b/e2e/e2e-node-esm/test/live_v2_session.test.ts
@@ -1,4 +1,9 @@
-import { GladiaClient, type LiveV2TranscriptMessage } from '@gladiaio/sdk'
+import {
+  GladiaClient,
+  type LiveV2NamedEntityRecognitionMessage,
+  type LiveV2NamedEntityRecognitionResult,
+  type LiveV2TranscriptMessage,
+} from '@gladiaio/sdk'
 import { parseAudioFile, sendAudioFile } from '@gladiaio/sdk-e2e-javascript-fixtures'
 import assert from 'node:assert'
 import { test } from 'vitest'
@@ -46,5 +51,71 @@ test('split infinity', async () => {
   assert.match(
     transcripts.map((transcript) => transcript.data.utterance.text).join(' '),
     /^\ssplit infinity\p{P}*$/iu
+  )
+})
+
+test('named entity recognition: anna-and-sasha yields Sasha as NAME_GIVEN', async () => {
+  const audioFile = 'anna-and-sasha-16000.wav'
+  const audioData = parseAudioFile(audioFile)
+
+  const transcripts: LiveV2TranscriptMessage[] = []
+  const nerMessages: LiveV2NamedEntityRecognitionMessage[] = []
+  const liveSession = new GladiaClient().liveV2().startSession({
+    ...audioData.audioConfig,
+    language_config: {
+      languages: ['en'],
+    },
+    realtime_processing: {
+      named_entity_recognition: true,
+    },
+    messages_config: {
+      receive_final_transcripts: true,
+      receive_realtime_processing_events: true,
+    },
+  })
+  assert.equal(liveSession.status, 'starting')
+
+  liveSession.on('message', (message) => {
+    if (message.type === 'transcript') {
+      transcripts.push(message)
+    } else if (message.type === 'named_entity_recognition') {
+      nerMessages.push(message)
+    }
+  })
+  liveSession.once('error', (error) => {
+    console.error(error)
+  })
+
+  const endPromise = new Promise<void>((resolve) => {
+    liveSession.once('ended', () => {
+      resolve()
+    })
+  })
+
+  await sendAudioFile(audioData, liveSession, 50)
+  liveSession.stopRecording()
+  assert.equal(liveSession.status, 'ending')
+
+  await endPromise
+  assert.equal(liveSession.status, 'ended')
+
+  const full = transcripts
+    .map((t) => t.data.utterance.text)
+    .join(' ')
+    .toLowerCase()
+  assert(full.includes('sasha'), 'expected transcript to contain sasha')
+
+  const rawResults: LiveV2NamedEntityRecognitionResult[] = []
+  for (const msg of nerMessages) {
+    if (msg.data?.results) {
+      rawResults.push(...msg.data.results)
+    }
+  }
+  const sashaAsGiven = rawResults.filter(
+    (r) => r.text.toLowerCase().includes('sasha') && r.entity_type.toUpperCase() === 'NAME_GIVEN'
+  )
+  assert(
+    sashaAsGiven.length > 0,
+    `expected NAME_GIVEN entity for Sasha, got ${JSON.stringify(rawResults.map((r) => [r.entity_type, r.text]))}`
   )
 })

--- a/e2e/e2e-python/tests/test_live_v2_async_session.py
+++ b/e2e/e2e-python/tests/test_live_v2_async_session.py
@@ -11,6 +11,9 @@ from gladiaio_sdk import (
   LiveV2EndedMessage,
   LiveV2InitRequest,
   LiveV2LanguageConfig,
+  LiveV2MessagesConfig,
+  LiveV2NamedEntityRecognitionMessage,
+  LiveV2RealtimeProcessingConfig,
   LiveV2TranscriptMessage,
   LiveV2WebSocketMessage,
 )
@@ -74,4 +77,74 @@ async def test_live_v2_async_session():
     rf"^\ssplit infinity[{re.escape(string.punctuation)}]*$",
     " ".join(transcript.data.utterance.text for transcript in transcripts),
     re.IGNORECASE,
+  )
+
+
+@pytest.mark.asyncio
+async def test_live_v2_async_named_entity_recognition_detects_sasha_as_given_name():
+  """Named entity recognition (live): anna-and-sasha audio should yield Sasha as NAME_GIVEN."""
+  audio_file = "anna-and-sasha-16000.wav"
+  audio_data = parse_audio_file(audio_file)
+
+  transcripts: list[LiveV2TranscriptMessage] = []
+  ner_messages: list[LiveV2NamedEntityRecognitionMessage] = []
+  ended_event = asyncio.Event()
+
+  live_session = (
+    GladiaClient()
+    .live_v2_async()
+    .start_session(
+      LiveV2InitRequest(
+        **audio_data["audio_config"],
+        language_config=LiveV2LanguageConfig(languages=["en"]),
+        realtime_processing=LiveV2RealtimeProcessingConfig(named_entity_recognition=True),
+        messages_config=LiveV2MessagesConfig(
+          receive_final_transcripts=True,
+          receive_realtime_processing_events=True,
+        ),
+      )
+    )
+  )
+  assert live_session.status == "starting"
+
+  @live_session.on("message")
+  def handle_message(message: LiveV2WebSocketMessage):  # pyright: ignore[reportUnusedFunction]
+    if message.type == "transcript":
+      transcripts.append(message)
+    elif message.type == "named_entity_recognition":
+      ner_messages.append(message)
+
+  @live_session.once("error")
+  def handle_error(error: Exception):  # pyright: ignore[reportUnusedFunction]
+    if isinstance(error, HttpError):
+      print(f"HttpError: {error.response_body} | {error}")
+    else:
+      print(error)
+
+  @live_session.once("ended")
+  def handle_ended(ended: LiveV2EndedMessage):  # pyright: ignore[reportUnusedFunction]
+    print(f"Session ended: {ended}")
+    ended_event.set()
+
+  await send_audio_file_async(audio_data, live_session)
+  live_session.stop_recording()
+  assert live_session.status == "ending"
+
+  _ = await ended_event.wait()
+  assert live_session.status == "ended"
+
+  full = " ".join(t.data.utterance.text for t in transcripts).lower()
+  assert "sasha" in full
+
+  raw_results: list = []
+  for msg in ner_messages:
+    if msg.data is not None:
+      raw_results.extend(msg.data.results)
+
+  sasha_as_given = [
+    r for r in raw_results if "sasha" in r.text.lower() and r.entity_type.upper() == "NAME_GIVEN"
+  ]
+  assert sasha_as_given, (
+    "expected a NAME_GIVEN entity whose text includes Sasha; "
+    f"got {[(r.entity_type, r.text) for r in raw_results]}"
   )

--- a/e2e/e2e-python/tests/test_live_v2_session.py
+++ b/e2e/e2e-python/tests/test_live_v2_session.py
@@ -11,6 +11,9 @@ from gladiaio_sdk import (
   LiveV2EndedMessage,
   LiveV2InitRequest,
   LiveV2LanguageConfig,
+  LiveV2MessagesConfig,
+  LiveV2NamedEntityRecognitionMessage,
+  LiveV2RealtimeProcessingConfig,
   LiveV2TranscriptMessage,
   LiveV2WebSocketMessage,
 )
@@ -87,4 +90,82 @@ def test_live_v2_session():
     rf"^\ssplit infinity[{re.escape(string.punctuation)}]*$",
     " ".join(transcript.data.utterance.text for transcript in transcripts),
     re.IGNORECASE,
+  )
+
+
+def test_live_v2_named_entity_recognition_detects_sasha_as_given_name():
+  """Named entity recognition (live): anna-and-sasha audio should yield Sasha as NAME_GIVEN."""
+  audio_file = "anna-and-sasha-16000.wav"
+  audio_data = parse_audio_file(audio_file)
+
+  transcripts: list[LiveV2TranscriptMessage] = []
+  ner_messages: list[LiveV2NamedEntityRecognitionMessage] = []
+  ended_event = threading.Event()
+
+  live_session = (
+    GladiaClient()
+    .live_v2()
+    .start_session(
+      LiveV2InitRequest(
+        **audio_data["audio_config"],
+        language_config=LiveV2LanguageConfig(languages=["en"]),
+        realtime_processing=LiveV2RealtimeProcessingConfig(named_entity_recognition=True),
+        messages_config=LiveV2MessagesConfig(
+          receive_final_transcripts=True,
+          receive_realtime_processing_events=True,
+        ),
+      )
+    )
+  )
+  assert live_session.status == "starting"
+
+  @live_session.on("message")
+  def handle_message(message: LiveV2WebSocketMessage):  # pyright: ignore[reportUnusedFunction]
+    if message.type == "transcript":
+      transcripts.append(message)
+    elif message.type == "named_entity_recognition":
+      ner_messages.append(message)
+
+  @live_session.once("error")
+  def handle_error(error: Exception):  # pyright: ignore[reportUnusedFunction]
+    if isinstance(error, HttpError):
+      print(f"HttpError: {error.response_body} | {error}")
+    else:
+      print(error)
+
+  @live_session.once("ended")
+  def handle_ended(ended: LiveV2EndedMessage):  # pyright: ignore[reportUnusedFunction]
+    print(f"Session ended: {ended}")
+    ended_event.set()
+
+  def _send_audio_thread() -> None:
+    chunk_size = compute_chunk_size(audio_data, 0.05)
+    for i in range(0, len(audio_data["raw_audio_data"]), chunk_size):
+      if live_session.status == "ending" or live_session.status == "ended":
+        break
+      live_session.send_audio(audio_data["raw_audio_data"][i : i + chunk_size])
+      sleep(0.05)
+    live_session.stop_recording()
+
+  sender = threading.Thread(target=_send_audio_thread, name="live-v2-ner-sender", daemon=True)
+  sender.start()
+
+  assert live_session.wait_until_ready(30.0) is True
+  assert ended_event.wait(120.0) is True
+  assert live_session.status == "ended"
+
+  full = " ".join(t.data.utterance.text for t in transcripts).lower()
+  assert "sasha" in full
+
+  raw_results: list = []
+  for msg in ner_messages:
+    if msg.data is not None:
+      raw_results.extend(msg.data.results)
+
+  sasha_as_given = [
+    r for r in raw_results if "sasha" in r.text.lower() and r.entity_type.upper() == "NAME_GIVEN"
+  ]
+  assert sasha_as_given, (
+    "expected a NAME_GIVEN entity whose text includes Sasha; "
+    f"got {[(r.entity_type, r.text) for r in raw_results]}"
   )

--- a/e2e/e2e-python/tests/test_prerecorded_v2_async.py
+++ b/e2e/e2e-python/tests/test_prerecorded_v2_async.py
@@ -175,6 +175,35 @@ async def test_transcribe_with_options_dict():
 
 
 @pytest.mark.asyncio
+async def test_transcribe_named_entity_recognition_detects_sasha_as_given_name():
+  """Named entity recognition: anna-and-sasha audio should yield Sasha as NAME_GIVEN."""
+  audio_path = _data_path("anna-and-sasha-16000.wav")
+  client = GladiaClient().pre_recorded_v2_async()
+  options = PreRecordedV2TranscriptionOptions(
+    language_config=PreRecordedV2LanguageConfig(languages=["en"]),
+    named_entity_recognition=True,
+  )
+  result = await client.transcribe(audio_url=audio_path, options=options, timeout=POLL_TIMEOUT_S)
+  assert result.status == "done"
+  assert result.result is not None
+  transcription = result.result.transcription
+  assert transcription is not None
+  full = (transcription.full_transcript or "").lower()
+  assert "sasha" in full
+  ner = result.result.named_entity_recognition
+  assert ner is not None
+  assert ner.success, f"NER addon failed: {ner.error}"
+  raw_results = ner.results or []
+  sasha_as_given = [
+    r for r in raw_results if "sasha" in r.text.lower() and r.entity_type.upper() == "NAME_GIVEN"
+  ]
+  assert sasha_as_given, (
+    "expected a NAME_GIVEN entity whose text includes Sasha; "
+    f"got {[(r.entity_type, r.text) for r in raw_results]}"
+  )
+
+
+@pytest.mark.asyncio
 async def test_transcribe_url():
   """Test async pre-recorded transcribe with URL (direct create + poll, no upload) returns done."""
   client = GladiaClient().pre_recorded_v2_async()

--- a/packages/sdk-js/src/v2/live/generated-types.ts
+++ b/packages/sdk-js/src/v2/live/generated-types.ts
@@ -557,7 +557,7 @@ export interface LiveV2NamedEntityRecognition {
   /** `null` if `success` is `true`. Contains the error details of the failed model */
   error: LiveV2AddonError | null
   /** If `named_entity_recognition` has been enabled, the detected entities. */
-  entity: string
+  results: Array<LiveV2NamedEntityRecognitionResult> | null
 }
 
 export interface LiveV2SentimentAnalysis {

--- a/packages/sdk-js/src/v2/prerecorded/generated-types.ts
+++ b/packages/sdk-js/src/v2/prerecorded/generated-types.ts
@@ -313,6 +313,8 @@ export interface PreRecordedV2CustomSpellingConfig {
 export interface PreRecordedV2AudioToLlmListConfig {
   /** The list of prompts applied on the audio transcription */
   prompts: Array<Array<any>>
+  /** The model to use for the prompt execution. You can find the list of supported models [here](https://openrouter.ai/models). */
+  model?: string
 }
 
 export type PreRecordedV2PiiRedactionEntityType =
@@ -401,9 +403,9 @@ export type PreRecordedV2PiiRedactionEntityType =
 
 export interface PreRecordedV2PiiRedactionConfig {
   /** The entity types to redact */
-  entity_types: PreRecordedV2PiiRedactionEntityType
+  entity_types?: PreRecordedV2PiiRedactionEntityType
   /** The type of processed text to return (marker or mask) */
-  processed_text_type: 'MARKER' | 'MASK'
+  processed_text_type?: 'MARKER' | 'MASK'
 }
 
 export interface PreRecordedV2LanguageConfig {
@@ -615,6 +617,13 @@ export interface PreRecordedV2Moderation {
   results: string | null
 }
 
+export interface PreRecordedV2NamedEntityRecognitionResult {
+  entity_type: string
+  text: string
+  start: number
+  end: number
+}
+
 export interface PreRecordedV2NamedEntityRecognition {
   /** The audio intelligence model succeeded to get a valid output */
   success: boolean
@@ -625,7 +634,7 @@ export interface PreRecordedV2NamedEntityRecognition {
   /** `null` if `success` is `true`. Contains the error details of the failed model */
   error: PreRecordedV2AddonError | null
   /** If `named_entity_recognition` has been enabled, the detected entities. */
-  entity: string
+  results: Array<PreRecordedV2NamedEntityRecognitionResult> | null
 }
 
 export interface PreRecordedV2NamesConsistency {
@@ -637,7 +646,7 @@ export interface PreRecordedV2NamesConsistency {
   exec_time: number
   /** `null` if `success` is `true`. Contains the error details of the failed model */
   error: PreRecordedV2AddonError | null
-  /** If `name_consistency` has been enabled, Gladia will improve the consistency of the names across the transcription */
+  /** Deprecated, If `name_consistency` has been enabled, Gladia will improve the consistency of the names across the transcription */
   results: string
 }
 

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/generated_types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/generated_types.py
@@ -616,10 +616,10 @@ class LiveV2NamedEntityRecognition(BaseDataClass):
   is_empty: bool
   # Time audio intelligence model took to complete the task
   exec_time: float
-  # If `named_entity_recognition` has been enabled, the detected entities.
-  entity: str
   # `null` if `success` is `true`. Contains the error details of the failed model
   error: LiveV2AddonError | None = None
+  # If `named_entity_recognition` has been enabled, the detected entities.
+  results: list[LiveV2NamedEntityRecognitionResult] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/generated_types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/generated_types.py
@@ -351,6 +351,9 @@ class PreRecordedV2CustomSpellingConfig(BaseDataClass):
 class PreRecordedV2AudioToLlmListConfig(BaseDataClass):
   # The list of prompts applied on the audio transcription
   prompts: list[list[Any]]
+  # The model to use for the prompt execution. You can find the list of supported models
+  # [here](https://openrouter.ai/models).
+  model: str | None = None
 
 
 PreRecordedV2PiiRedactionEntityType = Literal[
@@ -442,9 +445,9 @@ PreRecordedV2PiiRedactionEntityType = Literal[
 @dataclass(frozen=True, slots=True)
 class PreRecordedV2PiiRedactionConfig(BaseDataClass):
   # The entity types to redact
-  entity_types: PreRecordedV2PiiRedactionEntityType
+  entity_types: PreRecordedV2PiiRedactionEntityType | None = None
   # The type of processed text to return (marker or mask)
-  processed_text_type: Literal["MARKER", "MASK"]
+  processed_text_type: Literal["MARKER", "MASK"] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -677,6 +680,14 @@ class PreRecordedV2Moderation(BaseDataClass):
 
 
 @dataclass(frozen=True, slots=True)
+class PreRecordedV2NamedEntityRecognitionResult(BaseDataClass):
+  entity_type: str
+  text: str
+  start: float
+  end: float
+
+
+@dataclass(frozen=True, slots=True)
 class PreRecordedV2NamedEntityRecognition(BaseDataClass):
   # The audio intelligence model succeeded to get a valid output
   success: bool
@@ -684,10 +695,10 @@ class PreRecordedV2NamedEntityRecognition(BaseDataClass):
   is_empty: bool
   # Time audio intelligence model took to complete the task
   exec_time: float
-  # If `named_entity_recognition` has been enabled, the detected entities.
-  entity: str
   # `null` if `success` is `true`. Contains the error details of the failed model
   error: PreRecordedV2AddonError | None = None
+  # If `named_entity_recognition` has been enabled, the detected entities.
+  results: list[PreRecordedV2NamedEntityRecognitionResult] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -698,8 +709,8 @@ class PreRecordedV2NamesConsistency(BaseDataClass):
   is_empty: bool
   # Time audio intelligence model took to complete the task
   exec_time: float
-  # If `name_consistency` has been enabled, Gladia will improve the consistency of the names
-  # across the transcription
+  # Deprecated, If `name_consistency` has been enabled, Gladia will improve the consistency of the
+  # names across the transcription
   results: str
   # `null` if `success` is `true`. Contains the error details of the failed model
   error: PreRecordedV2AddonError | None = None


### PR DESCRIPTION
Summary
Updates generated SDK types so named_entity_recognition matches what the API returns, and adds end-to-end coverage that asserts detected name entities.

Problem
While validating the SDK against a real response, named_entity_recognition did not line up with runtime data. The spec described a single string field:

{ "entity": "<string>" }
The API actually returns a list of spans with type, text, and time bounds, for example:

{
  "results": [
    {
      "entity_type": "NAME_GIVEN",
      "text": "Sasha",
      "start": 1.476,
      "end": 1.716
    }
  ]
}

Solution
Redo the generator to match the openapi.

Apply this in pre-recorded and live generated types for both Python and JavaScript SDKs.
Add e2e tests (Python and Node) that enable NER and assert at least one name-related entity (e.g. NAME_GIVEN / NAME_FAMILY / NAME).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Named entity recognition now returns structured results including entity type and text position information.
  * Optional model selection added for audio-to-LLM transcription.

* **Improvements**
  * PII redaction configuration options are now optional for greater flexibility.

* **Deprecations**
  * Names consistency feature marked as deprecated.

* **Tests**
  * Added end-to-end tests for named entity recognition functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->