### PR TITLE
Update project.json to remove lockedVersions

### DIFF
--- a/e2e/e2e-python/tests/helpers.py
+++ b/e2e/e2e-python/tests/helpers.py
@@ -3,12 +3,8 @@ from asyncio import sleep as async_sleep
 from time import sleep
 from typing import TypedDict, cast
 
-from gladiaio_sdk import (
-  LiveV2AsyncSession,
-  LiveV2BitDepth,
-  LiveV2Encoding,
-  LiveV2SampleRate,
-)
+from gladiaio_sdk import LiveV2AsyncSession
+from gladiaio_sdk.v2.live.generated_types import LiveV2BitDepth, LiveV2Encoding, LiveV2SampleRate
 
 
 class LiveV2InitRequestAudioConfig(TypedDict):

--- a/e2e/e2e-python/tests/test_live_v2_async_session.py
+++ b/e2e/e2e-python/tests/test_live_v2_async_session.py
@@ -9,6 +9,8 @@ from gladiaio_sdk import (
   GladiaClient,
   HttpError,
   LiveV2EndedMessage,
+)
+from gladiaio_sdk.v2.live.generated_types import (
   LiveV2InitRequest,
   LiveV2LanguageConfig,
   LiveV2MessagesConfig,

--- a/e2e/e2e-python/tests/test_live_v2_session.py
+++ b/e2e/e2e-python/tests/test_live_v2_session.py
@@ -9,6 +9,8 @@ from gladiaio_sdk import (
   GladiaClient,
   HttpError,
   LiveV2EndedMessage,
+)
+from gladiaio_sdk.v2.live.generated_types import (
   LiveV2InitRequest,
   LiveV2LanguageConfig,
   LiveV2MessagesConfig,

--- a/e2e/e2e-python/tests/test_prerecorded_v2_async.py
+++ b/e2e/e2e-python/tests/test_prerecorded_v2_async.py
@@ -8,9 +8,11 @@ import pytest
 from gladiaio_sdk import (
   GladiaClient,
   HttpError,
+  PreRecordedV2TranscriptionOptions,
+)
+from gladiaio_sdk.v2.prerecorded.generated_types import (
   PreRecordedV2InitTranscriptionRequest,
   PreRecordedV2LanguageConfig,
-  PreRecordedV2TranscriptionOptions,
 )
 
 

--- a/packages/sdk-python/project.json
+++ b/packages/sdk-python/project.json
@@ -50,7 +50,7 @@
       "options": {
         "outputPath": "{projectRoot}/dist",
         "publish": true,
-        "lockedVersions": true,
+        "lockedVersions": false,
         "bundleLocalDependencies": true
       },
       "cache": true


### PR DESCRIPTION
The wheel published to PyPI was embedding exact pinned versions instead of the broad ranges declared in pyproject.toml. This caused resolver conflicts for downstream users integrating the SDK into existing applications.
 
The root cause was `"lockedVersions": true` in packages/sdk-python/project.json, which made @nxlv/python:build rewrite the package metadata from the uv lockfile. Setting it to false restores the intended library-style ranges.
  
Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Python SDK build configuration to disable strict locking of dependency versions during builds.
* **Tests**
  * Fixed and simplified import statements across end-to-end Python tests to resolve syntax issues and tidy imports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gladiaio/sdk/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->