### PR TITLE
feat: add job management methods to live V2 client (get, delete, getFile)

### DIFF
--- a/e2e/e2e-node-cjs/test/live_v2_job_management.test.cjs
+++ b/e2e/e2e-node-cjs/test/live_v2_job_management.test.cjs
@@ -1,0 +1,76 @@
+/**
+ * Live V2 job management (e2e) tests — get, getFile, delete.
+ *
+ * Each test starts a live session, streams a short audio clip, waits for
+ * the session to end, then exercises the HTTP job-management method.
+ */
+
+const { GladiaClient } = require('@gladiaio/sdk')
+const { parseAudioFile, sendAudioFile } = require('@gladiaio/sdk-e2e-javascript-fixtures')
+const assert = require('node:assert')
+const { test } = require('node:test')
+
+const AUDIO_FILE = 'short_split_infinity_16k.wav'
+
+/**
+ * Run a full live session and return the job ID once the session has ended.
+ */
+async function runLiveSession() {
+  const audioData = parseAudioFile(AUDIO_FILE)
+  const client = new GladiaClient()
+  const liveSession = client.liveV2().startSession({
+    ...audioData.audioConfig,
+    language_config: { languages: ['en'] },
+  })
+
+  const endPromise = new Promise((resolve) => {
+    liveSession.once('ended', () => resolve())
+  })
+  liveSession.once('error', (error) => console.error(error))
+
+  await sendAudioFile(audioData, liveSession, 50)
+  liveSession.stopRecording()
+  await endPromise
+
+  const jobId = await liveSession.getSessionId()
+  assert(jobId, 'expected a session id after the session ended')
+  return jobId
+}
+
+test('get: returns live job metadata after session ends', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const result = await client.get(jobId)
+  assert.strictEqual(result.id, jobId)
+  assert(
+    result.status === 'done' || result.status === 'processing',
+    `unexpected status: ${result.status}`
+  )
+  assert.strictEqual(result.kind, 'live')
+})
+
+test('getFile: returns audio bytes with RIFF header', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const fileBytes = await client.getFile(jobId)
+  assert(fileBytes instanceof ArrayBuffer)
+  assert(fileBytes.byteLength > 0)
+  const header = new Uint8Array(fileBytes, 0, 4)
+  assert.strictEqual(String.fromCharCode(...header), 'RIFF')
+})
+
+test('delete: returns true on success (HTTP 202)', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const deleted = await client.delete(jobId)
+  assert.strictEqual(deleted, true)
+})
+
+test('delete: throws with status 404 when job does not exist', async () => {
+  const client = new GladiaClient().liveV2()
+  const nonexistentId = '00000000-0000-0000-0000-000000000000'
+  await assert.rejects(
+    async () => client.delete(nonexistentId),
+    (err) => err.status === 404
+  )
+})

--- a/e2e/e2e-node-esm/test/live_v2_job_management.test.ts
+++ b/e2e/e2e-node-esm/test/live_v2_job_management.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Live V2 job management (e2e) tests — get, getFile, delete.
+ *
+ * Each test starts a live session, streams a short audio clip, waits for
+ * the session to end, then exercises the HTTP job-management method.
+ */
+
+import { GladiaClient, type LiveV2Response } from '@gladiaio/sdk'
+import { parseAudioFile, sendAudioFile } from '@gladiaio/sdk-e2e-javascript-fixtures'
+import assert from 'node:assert'
+import { test } from 'vitest'
+
+const AUDIO_FILE = 'short_split_infinity_16k.wav'
+
+/**
+ * Run a full live session and return the job ID once the session has ended.
+ */
+async function runLiveSession(): Promise<string> {
+  const audioData = parseAudioFile(AUDIO_FILE)
+  const client = new GladiaClient()
+  const liveSession = client.liveV2().startSession({
+    ...audioData.audioConfig,
+    language_config: { languages: ['en'] },
+  })
+
+  const endPromise = new Promise<void>((resolve) => {
+    liveSession.once('ended', () => resolve())
+  })
+  liveSession.once('error', (error) => console.error(error))
+
+  await sendAudioFile(audioData, liveSession, 50)
+  liveSession.stopRecording()
+  await endPromise
+
+  const jobId = await liveSession.getSessionId()
+  assert(jobId, 'expected a session id after the session ended')
+  return jobId
+}
+
+test('get: returns live job metadata after session ends', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const result: LiveV2Response = await client.get(jobId)
+  assert.strictEqual(result.id, jobId)
+  assert(
+    result.status === 'done' || result.status === 'processing',
+    `unexpected status: ${result.status}`
+  )
+  assert.strictEqual(result.kind, 'live')
+})
+
+test('getFile: returns audio bytes with RIFF header', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const fileBytes = await client.getFile(jobId)
+  assert(fileBytes instanceof ArrayBuffer)
+  assert(fileBytes.byteLength > 0)
+  const header = new Uint8Array(fileBytes, 0, 4)
+  assert.strictEqual(String.fromCharCode(...header), 'RIFF')
+})
+
+test('delete: returns true on success (HTTP 202)', async () => {
+  const jobId = await runLiveSession()
+  const client = new GladiaClient().liveV2()
+  const deleted = await client.delete(jobId)
+  assert.strictEqual(deleted, true)
+})
+
+test('delete: throws with status 404 when job does not exist', async () => {
+  const client = new GladiaClient().liveV2()
+  const nonexistentId = '00000000-0000-0000-0000-000000000000'
+  await assert.rejects(
+    async () => client.delete(nonexistentId),
+    (err: unknown) => (err as { status?: number }).status === 404
+  )
+})

--- a/e2e/e2e-python/tests/test_live_v2_job_management.py
+++ b/e2e/e2e-python/tests/test_live_v2_job_management.py
@@ -1,0 +1,92 @@
+"""Live V2 job management (e2e) tests — get, get_file, delete.
+
+Each test starts a live session, streams a short audio clip, waits for
+the session to end, then exercises the HTTP job-management method.
+"""
+
+import asyncio
+
+import pytest
+from gladiaio_sdk import GladiaClient, HttpError
+from gladiaio_sdk.v2.live.generated_types import (
+  LiveV2InitRequest,
+  LiveV2LanguageConfig,
+)
+
+from tests.helpers import parse_audio_file, send_audio_file_async
+
+AUDIO_FILE = "short_split_infinity_16k.wav"
+
+
+async def _run_live_session() -> str:
+  """Run a full live session and return the job ID once the session has ended."""
+  audio_data = parse_audio_file(AUDIO_FILE)
+  ended_event = asyncio.Event()
+
+  live_session = (
+    GladiaClient()
+    .live_v2_async()
+    .start_session(
+      LiveV2InitRequest(
+        **audio_data["audio_config"],
+        language_config=LiveV2LanguageConfig(languages=["en"]),
+      )
+    )
+  )
+
+  @live_session.once("error")
+  def handle_error(error: Exception):  # pyright: ignore[reportUnusedFunction]
+    print(f"Live session error: {error}")
+
+  @live_session.once("ended")
+  def handle_ended(ended):  # pyright: ignore[reportUnusedFunction]
+    ended_event.set()
+
+  await send_audio_file_async(audio_data, live_session)
+  live_session.stop_recording()
+  await ended_event.wait()
+
+  job_id = await live_session.get_session_id()
+  assert job_id, "expected a session id after the session ended"
+  return job_id
+
+
+@pytest.mark.asyncio
+async def test_get():
+  """get returns live job metadata after session ends."""
+  job_id = await _run_live_session()
+  client = GladiaClient().live_v2_async()
+  result = await client.get(job_id)
+  assert result.id == job_id
+  assert result.status in ("done", "processing")
+  assert result.kind == "live"
+
+
+@pytest.mark.asyncio
+async def test_get_file():
+  """get_file returns audio bytes with RIFF header."""
+  job_id = await _run_live_session()
+  client = GladiaClient().live_v2_async()
+  file_bytes = await client.get_file(job_id)
+  assert isinstance(file_bytes, bytes)
+  assert len(file_bytes) > 0
+  assert file_bytes[:4] == b"RIFF"
+
+
+@pytest.mark.asyncio
+async def test_delete():
+  """delete returns True when job is correctly removed (HTTP 202)."""
+  job_id = await _run_live_session()
+  client = GladiaClient().live_v2_async()
+  deleted = await client.delete(job_id)
+  assert deleted is True
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent():
+  """delete raises HttpError (404) when job does not exist."""
+  client = GladiaClient().live_v2_async()
+  nonexistent_id = "00000000-0000-0000-0000-000000000000"
+  with pytest.raises(HttpError) as exc_info:
+    await client.delete(nonexistent_id)
+  assert exc_info.value.status == 404

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -45,6 +45,8 @@ export class Generator {
   private preProcessSchemaForLiveV2(openapi: OpenAPIObject): LiveV2Schemas {
     const initRequestRef = `#/components/schemas/StreamingRequest`
     const initResponseRef = `#/components/schemas/InitStreamingResponse`
+    const getResponseRef = `#/components/schemas/StreamingResponse`
+    const listResponseRef = `#/components/schemas/ListStreamingResponse`
     const wsMessagesRef: string[] = []
     const callbackMessagesRef: string[] = []
     const webhookMessagesRef: string[] = []
@@ -52,6 +54,8 @@ export class Generator {
 
     collectAllReferencedObject({ $ref: initRequestRef }, openapi, referencedTypes)
     collectAllReferencedObject({ $ref: initResponseRef }, openapi, referencedTypes)
+    collectAllReferencedObject({ $ref: getResponseRef }, openapi, referencedTypes)
+    collectAllReferencedObject({ $ref: listResponseRef }, openapi, referencedTypes)
 
     for (const key of Object.keys(openapi.components?.schemas ?? {})) {
       if (key.match(/^CallbackLive.*Message$/)) {
@@ -76,6 +80,10 @@ export class Generator {
           acc.initRequest = refObject
         } else if (ref === initResponseRef) {
           acc.initResponse = refObject
+        } else if (ref === getResponseRef) {
+          acc.getResponse = refObject
+        } else if (ref === listResponseRef) {
+          acc.listResponse = refObject
         } else if (wsMessagesRef.includes(ref)) {
           acc.wsMessages.push(refObject)
         } else if (callbackMessagesRef.includes(ref)) {
@@ -94,6 +102,8 @@ export class Generator {
       {
         initRequest: referencedTypes.get(initRequestRef)!,
         initResponse: referencedTypes.get(initResponseRef)!,
+        getResponse: referencedTypes.get(getResponseRef)!,
+        listResponse: referencedTypes.get(listResponseRef)!,
         wsMessages: [],
         callbackMessages: [],
         webhookMessages: [],
@@ -116,8 +126,15 @@ export class Generator {
     const initRequestRef = `#/components/schemas/InitTranscriptionRequest`
     const initResponseRef = `#/components/schemas/InitPreRecordedTranscriptionResponse`
     const resultResponseRef = `#/components/schemas/PreRecordedResponse`
+    const listResponseRef = `#/components/schemas/ListPreRecordedResponse`
 
-    const rootRefs = [uploadResponseRef, initRequestRef, initResponseRef, resultResponseRef]
+    const rootRefs = [
+      uploadResponseRef,
+      initRequestRef,
+      initResponseRef,
+      resultResponseRef,
+      listResponseRef,
+    ]
     const referencedTypes: Map<string, ReferencedSchemaObject> = new Map()
 
     for (const ref of rootRefs) {
@@ -151,6 +168,8 @@ export class Generator {
           acc.initResponse = refObject
         } else if (ref === resultResponseRef) {
           acc.resultResponse = refObject
+        } else if (ref === listResponseRef) {
+          acc.listResponse = refObject
         } else {
           acc.referencedTypes.push(refObject)
         }
@@ -165,6 +184,7 @@ export class Generator {
         initRequest: referencedTypes.get(initRequestRef)!,
         initResponse: referencedTypes.get(initResponseRef)!,
         resultResponse: referencedTypes.get(resultResponseRef)!,
+        listResponse: referencedTypes.get(listResponseRef)!,
         referencedTypes: [],
       }
     )

--- a/packages/generator/src/generators/base.ts
+++ b/packages/generator/src/generators/base.ts
@@ -43,6 +43,10 @@ export abstract class BaseGenerator {
       '\n\n' +
       (await this.generateTypes([schemas.initRequest, schemas.initResponse], 'Init Session'))
 
+    const jobManagementContent =
+      '\n\n' +
+      (await this.generateTypes([schemas.getResponse, schemas.listResponse], 'Job Management'))
+
     const wsMessagesContent =
       '\n\n' +
       (await this.generateTypes(schemas.wsMessages, 'WebSocket Messages')) +
@@ -82,6 +86,7 @@ export abstract class BaseGenerator {
       header,
       sharedContent,
       initSessionContent,
+      jobManagementContent,
       wsMessagesContent,
       callbackMessagesContent,
       webhookMessagesContent,
@@ -111,8 +116,17 @@ export abstract class BaseGenerator {
 
     const resultContent = '\n\n' + (await this.generateTypes([schemas.resultResponse], 'Result'))
 
+    const listContent = '\n\n' + (await this.generateTypes([schemas.listResponse], 'List'))
+
     const header = this.getGeneratedFileHeader()
-    const allContent = [header, sharedContent, uploadContent, initSessionContent, resultContent]
+    const allContent = [
+      header,
+      sharedContent,
+      uploadContent,
+      initSessionContent,
+      resultContent,
+      listContent,
+    ]
       .filter((content) => content.trim())
       .join('\n\n')
 

--- a/packages/generator/src/generators/python.ts
+++ b/packages/generator/src/generators/python.ts
@@ -52,9 +52,9 @@ export class PythonGenerator extends BaseGenerator {
   // Format: 'TypeName.fieldName' -> true means force optional
   // This is useful when API behavior doesn't match OpenAPI schema exactly
   private fieldOverrides: Map<string, boolean> = new Map([
-    // PreRecordedResponse fields that should be optional despite schema
     // These debug/metadata fields are not always returned by the API
     ['PreRecordedV2Response.post_session_metadata', true],
+    ['LiveV2Response.post_session_metadata', true],
   ])
 
   constructor() {

--- a/packages/generator/src/generators/typescript.ts
+++ b/packages/generator/src/generators/typescript.ts
@@ -8,9 +8,9 @@ export class TypeScriptGenerator extends BaseGenerator {
   // Format: 'TypeName.fieldName' -> true means force optional
   // This is useful when API behavior doesn't match OpenAPI schema exactly
   private fieldOverrides: Map<string, boolean> = new Map([
-    // PreRecordedResponse fields that should be optional despite schema
     // These debug/metadata fields are not always returned by the API
     ['PreRecordedV2Response.post_session_metadata', true],
+    ['LiveV2Response.post_session_metadata', true],
   ])
 
   override get sdkName(): string {

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -44,6 +44,8 @@ export type SchemaObjectRefLess = Omit<
 export type LiveV2Schemas = {
   initRequest: ReferencedSchemaObject
   initResponse: ReferencedSchemaObject
+  getResponse: ReferencedSchemaObject
+  listResponse: ReferencedSchemaObject
   wsMessages: ReferencedSchemaObject[]
   callbackMessages: ReferencedSchemaObject[]
   webhookMessages: ReferencedSchemaObject[]
@@ -56,5 +58,6 @@ export type PreRecordedV2Schemas = {
   initRequest: ReferencedSchemaObject
   initResponse: ReferencedSchemaObject
   resultResponse: ReferencedSchemaObject
+  listResponse: ReferencedSchemaObject
   referencedTypes: ReferencedSchemaObject[]
 }

--- a/packages/sdk-js/src/client.ts
+++ b/packages/sdk-js/src/client.ts
@@ -76,6 +76,11 @@ const defaultOptions: InternalGladiaClientOptions = {
     delete: 60_000,
     get: 10_000,
   },
+  liveTimeouts: {
+    get: 10_000,
+    delete: 60_000,
+    getFile: 300_000,
+  },
 }
 
 /**

--- a/packages/sdk-js/src/internal_types.ts
+++ b/packages/sdk-js/src/internal_types.ts
@@ -7,6 +7,7 @@ import type { Headers } from './network/types.js'
 import type {
   GladiaClientOptions,
   HttpRetryOptions,
+  LiveV2Timeouts,
   PreRecordedV2Timeouts,
   WebSocketRetryOptions,
 } from './types.js'
@@ -20,11 +21,17 @@ export type InternalGladiaClientOptions = Pick<GladiaClientOptions, OptionalGlad
   Required<
     Omit<
       GladiaClientOptions,
-      OptionalGladiaClientOptions | 'httpHeaders' | 'httpRetry' | 'wsRetry' | 'prerecordedTimeouts'
+      | OptionalGladiaClientOptions
+      | 'httpHeaders'
+      | 'httpRetry'
+      | 'wsRetry'
+      | 'prerecordedTimeouts'
+      | 'liveTimeouts'
     >
   > & {
     httpHeaders: Headers
     httpRetry: InternalHttpRetryOptions
     wsRetry: InternalWebSocketRetryOptions
     prerecordedTimeouts: Required<PreRecordedV2Timeouts>
+    liveTimeouts: Required<LiveV2Timeouts>
   }

--- a/packages/sdk-js/src/types.ts
+++ b/packages/sdk-js/src/types.ts
@@ -82,6 +82,15 @@ export type PreRecordedV2Timeouts = {
 }
 
 /**
+ * HTTP timeouts for live V2 job-management operations (milliseconds).
+ */
+export type LiveV2Timeouts = {
+  get?: number
+  delete?: number
+  getFile?: number
+}
+
+/**
  * Options for the Gladia Client.
  */
 export type GladiaClientOptions = {
@@ -154,4 +163,9 @@ export type GladiaClientOptions = {
    * Pre-recorded V2 per-operation timeouts. See {@link PreRecordedV2Timeouts}.
    */
   prerecordedTimeouts?: PreRecordedV2Timeouts
+
+  /**
+   * Live V2 per-operation timeouts. See {@link LiveV2Timeouts}.
+   */
+  liveTimeouts?: LiveV2Timeouts
 }

--- a/packages/sdk-js/src/v2/live/client.ts
+++ b/packages/sdk-js/src/v2/live/client.ts
@@ -10,10 +10,12 @@ import { LiveV2Session } from './session.js'
 export class LiveV2Client {
   private httpClient: HttpClient
   private webSocketClient: WebSocketClient
+  private readonly liveTimeouts: InternalGladiaClientOptions['liveTimeouts']
 
   constructor(options: InternalGladiaClientOptions) {
     const httpBaseUrl = new URL(options.apiUrl)
     httpBaseUrl.protocol = httpBaseUrl.protocol.replace(/^ws/, 'http')
+    this.liveTimeouts = options.liveTimeouts
     this.httpClient = new HttpClient({
       baseUrl: httpBaseUrl,
       headers: options.httpHeaders,
@@ -46,7 +48,9 @@ export class LiveV2Client {
    * @returns The full job response including status and result if done.
    */
   async get(jobId: string): Promise<LiveV2Response> {
-    return this.httpClient.get<LiveV2Response>(`/v2/live/${jobId}`)
+    return this.httpClient.get<LiveV2Response>(`/v2/live/${jobId}`, {
+      requestTimeout: this.liveTimeouts.get,
+    })
   }
 
   /**
@@ -59,6 +63,7 @@ export class LiveV2Client {
   async delete(jobId: string): Promise<boolean> {
     const response = await this.httpClient.delete<Response>(`/v2/live/${jobId}`, {
       rawResponse: true,
+      requestTimeout: this.liveTimeouts.delete,
     })
     return response.status === 202
   }
@@ -70,7 +75,10 @@ export class LiveV2Client {
    * @returns The raw audio file as an `ArrayBuffer`.
    */
   async getFile(jobId: string): Promise<ArrayBuffer> {
-    const response = await this.httpClient.get<Response>(`/v2/live/${jobId}/file`)
+    const response = await this.httpClient.get<Response>(`/v2/live/${jobId}/file`, {
+      rawResponse: true,
+      requestTimeout: this.liveTimeouts.getFile,
+    })
     return response.arrayBuffer()
   }
 }

--- a/packages/sdk-js/src/v2/live/client.ts
+++ b/packages/sdk-js/src/v2/live/client.ts
@@ -1,7 +1,7 @@
 import { InternalGladiaClientOptions } from '../../internal_types.js'
 import { HttpClient } from '../../network/httpClient.js'
 import { WebSocketClient } from '../../network/wsClient.js'
-import type { LiveV2InitRequest } from './generated-types.js'
+import type { LiveV2InitRequest, LiveV2Response } from './generated-types.js'
 import { LiveV2Session } from './session.js'
 
 /**
@@ -37,5 +37,40 @@ export class LiveV2Client {
       httpClient: this.httpClient,
       webSocketClient: this.webSocketClient,
     })
+  }
+
+  /**
+   * Get a live job by ID.
+   *
+   * @param jobId - The UUID of the live job.
+   * @returns The full job response including status and result if done.
+   */
+  async get(jobId: string): Promise<LiveV2Response> {
+    return this.httpClient.get<LiveV2Response>(`/v2/live/${jobId}`)
+  }
+
+  /**
+   * Delete a live job.
+   *
+   * @param jobId - The UUID of the live job to delete.
+   * @returns `true` if the job was deleted successfully (HTTP 202), `false` if the server responded with another 2xx status.
+   * @throws When the server responds with an error HTTP status (e.g. 404).
+   */
+  async delete(jobId: string): Promise<boolean> {
+    const response = await this.httpClient.delete<Response>(`/v2/live/${jobId}`, {
+      rawResponse: true,
+    })
+    return response.status === 202
+  }
+
+  /**
+   * Download the audio file for a live job.
+   *
+   * @param jobId - The UUID of the live job.
+   * @returns The raw audio file as an `ArrayBuffer`.
+   */
+  async getFile(jobId: string): Promise<ArrayBuffer> {
+    const response = await this.httpClient.get<Response>(`/v2/live/${jobId}/file`)
+    return response.arrayBuffer()
   }
 }

--- a/packages/sdk-js/src/v2/live/generated-types.ts
+++ b/packages/sdk-js/src/v2/live/generated-types.ts
@@ -350,105 +350,53 @@ export interface LiveV2CallbackConfig {
   receive_lifecycle_events?: boolean
 }
 
-export interface LiveV2Error {
-  /** The error message */
-  message: string
+export interface LiveV2FileResponse {
+  /** The file id */
+  id: string
+  /** The name of the uploaded file */
+  filename: string | null
+  /** The link used to download the file if audio_url was used */
+  source: string | null
+  /** Duration of the audio file */
+  audio_duration: number | null
+  /** Number of channels in the audio file */
+  number_of_channels: number | null
 }
 
-export interface LiveV2AudioChunkAckData {
-  /** Range in bytes length of the audio chunk (relative to the whole session) */
-  byte_range: Array<number>
-  /** Range in seconds of the audio chunk (relative to the whole session) */
-  time_range: Array<number>
-}
+export interface LiveV2RequestParamsResponse {
+  /** The encoding format of the audio stream. Supported formats: 
+- PCM: 8, 16, 24, and 32 bits 
+- A-law: 8 bits 
+- μ-law: 8 bits 
 
-export interface LiveV2EndRecordingMessageData {
-  /** Total audio duration in seconds */
-  recording_duration: number
-}
-
-export interface LiveV2Word {
-  /** Spoken word */
-  word: string
-  /** Start timestamps in seconds of the spoken word */
-  start: number
-  /** End timestamps in seconds of the spoken word */
-  end: number
-  /** Confidence on the transcribed word (1 = 100% confident) */
-  confidence: number
-}
-
-export interface LiveV2Utterance {
-  /** Start timestamp in seconds of this utterance */
-  start: number
-  /** End timestamp in seconds of this utterance */
-  end: number
-  /** Confidence on the transcribed utterance (1 = 100% confident) */
-  confidence: number
-  /** Audio channel of where this utterance has been transcribed from */
-  channel: number
-  /** If `diarization` enabled, speaker identification number */
-  speaker?: number
-  /** List of words of the utterance, split by timestamp */
-  words: Array<LiveV2Word>
-  /** Transcription for this utterance */
-  text: string
-  /** Spoken language in this utterance */
-  language: LiveV2TranscriptionLanguageCode
-}
-
-export interface LiveV2TranslationData {
-  /** Id of the utterance used for this result */
-  utterance_id: string
-  /** The transcribed utterance */
-  utterance: LiveV2Utterance
-  /** The original language in `iso639-1` or `iso639-2` format depending on the language */
-  original_language: LiveV2TranscriptionLanguageCode
-  /** The target language in `iso639-1` or `iso639-2` format depending on the language */
-  target_language: LiveV2TranslationLanguageCode
-  /** The translated utterance */
-  translated_utterance: LiveV2Utterance
-}
-
-export interface LiveV2NamedEntityRecognitionResult {
-  entity_type: string
-  text: string
-  start: number
-  end: number
-}
-
-export interface LiveV2NamedEntityRecognitionData {
-  /** Id of the utterance used for this result */
-  utterance_id: string
-  /** The transcribed utterance */
-  utterance: LiveV2Utterance
-  /** The NER results */
-  results: Array<LiveV2NamedEntityRecognitionResult>
-}
-
-export interface LiveV2ChapterizationSentence {
-  sentence: string
-  start: number
-  end: number
-  words: Array<LiveV2Word>
-}
-
-export interface LiveV2PostChapterizationResult {
-  abstractive_summary?: string
-  extractive_summary?: string
-  summary?: string
-  headline: string
-  gist: string
-  keywords: Array<string>
-  start: number
-  end: number
-  sentences: Array<LiveV2ChapterizationSentence>
-  text: string
-}
-
-export interface LiveV2PostChapterizationMessageData {
-  /** The chapters */
-  results: Array<LiveV2PostChapterizationResult>
+Note: No need to add WAV headers to raw audio as the API supports both formats. */
+  encoding?: LiveV2Encoding
+  /** The bit depth of the audio stream */
+  bit_depth?: LiveV2BitDepth
+  /** The sample rate of the audio stream */
+  sample_rate?: LiveV2SampleRate
+  /** The number of channels of the audio stream */
+  channels?: number
+  /** The model used to process the audio. "solaria-1" is used by default. */
+  model?: LiveV2Model
+  /** The endpointing duration in seconds. Endpointing is the duration of silence which will cause an utterance to be considered as finished */
+  endpointing?: number
+  /** The maximum duration in seconds without endpointing. If endpointing is not detected after this duration, current utterance will be considered as finished */
+  maximum_duration_without_endpointing?: number
+  /** Specify the language configuration */
+  language_config?: LiveV2LanguageConfig
+  /** Specify the pre-processing configuration */
+  pre_processing?: LiveV2PreProcessingConfig
+  /** Specify the realtime processing configuration */
+  realtime_processing?: LiveV2RealtimeProcessingConfig
+  /** Specify the post-processing configuration */
+  post_processing?: LiveV2PostProcessingConfig
+  /** Specify the websocket messages configuration */
+  messages_config?: LiveV2MessagesConfig
+  /** If true, messages will be sent to configured url. */
+  callback?: boolean
+  /** Specify the callback configuration */
+  callback_config?: LiveV2CallbackConfig
 }
 
 export interface LiveV2TranscriptionMetadata {
@@ -491,6 +439,36 @@ export interface LiveV2Subtitle {
   format: LiveV2SubtitlesFormat
   /** Transcription on the asked subtitle format */
   subtitles: string
+}
+
+export interface LiveV2Word {
+  /** Spoken word */
+  word: string
+  /** Start timestamps in seconds of the spoken word */
+  start: number
+  /** End timestamps in seconds of the spoken word */
+  end: number
+  /** Confidence on the transcribed word (1 = 100% confident) */
+  confidence: number
+}
+
+export interface LiveV2Utterance {
+  /** Start timestamp in seconds of this utterance */
+  start: number
+  /** End timestamp in seconds of this utterance */
+  end: number
+  /** Confidence on the transcribed utterance (1 = 100% confident) */
+  confidence: number
+  /** Audio channel of where this utterance has been transcribed from */
+  channel: number
+  /** If `diarization` enabled, speaker identification number */
+  speaker?: number
+  /** List of words of the utterance, split by timestamp */
+  words: Array<LiveV2Word>
+  /** Transcription for this utterance */
+  text: string
+  /** Spoken language in this utterance */
+  language: LiveV2TranscriptionLanguageCode
 }
 
 export interface LiveV2Transcription {
@@ -547,6 +525,13 @@ export interface LiveV2Summarization {
   results: string | null
 }
 
+export interface LiveV2NamedEntityRecognitionResult {
+  entity_type: string
+  text: string
+  start: number
+  end: number
+}
+
 export interface LiveV2NamedEntityRecognition {
   /** The audio intelligence model succeeded to get a valid output */
   success: boolean
@@ -584,6 +569,89 @@ export interface LiveV2Chapterization {
   error: LiveV2AddonError | null
   /** If `chapterization` has been enabled, will generate chapters name for different parts of the given audio. */
   results: Record<string, any>
+}
+
+export interface LiveV2TranscriptionResultWithMessages {
+  /** Metadata for the given transcription & audio file */
+  metadata: LiveV2TranscriptionMetadata
+  /** Transcription of the audio speech */
+  transcription?: LiveV2Transcription
+  /** If `translation` has been enabled, translation of the audio speech transcription */
+  translation?: LiveV2Translation
+  /** If `summarization` has been enabled, summarization of the audio speech transcription */
+  summarization?: LiveV2Summarization
+  /** If `named_entity_recognition` has been enabled, the detected entities */
+  named_entity_recognition?: LiveV2NamedEntityRecognition
+  /** If `sentiment_analysis` has been enabled, sentiment analysis of the audio speech transcription */
+  sentiment_analysis?: LiveV2SentimentAnalysis
+  /** If `chapterization` has been enabled, will generate chapters name for different parts of the given audio. */
+  chapterization?: LiveV2Chapterization
+  /** Real-Time messages sent by the server during the live transcription */
+  messages?: Array<string>
+}
+
+export interface LiveV2Error {
+  /** The error message */
+  message: string
+}
+
+export interface LiveV2AudioChunkAckData {
+  /** Range in bytes length of the audio chunk (relative to the whole session) */
+  byte_range: Array<number>
+  /** Range in seconds of the audio chunk (relative to the whole session) */
+  time_range: Array<number>
+}
+
+export interface LiveV2EndRecordingMessageData {
+  /** Total audio duration in seconds */
+  recording_duration: number
+}
+
+export interface LiveV2TranslationData {
+  /** Id of the utterance used for this result */
+  utterance_id: string
+  /** The transcribed utterance */
+  utterance: LiveV2Utterance
+  /** The original language in `iso639-1` or `iso639-2` format depending on the language */
+  original_language: LiveV2TranscriptionLanguageCode
+  /** The target language in `iso639-1` or `iso639-2` format depending on the language */
+  target_language: LiveV2TranslationLanguageCode
+  /** The translated utterance */
+  translated_utterance: LiveV2Utterance
+}
+
+export interface LiveV2NamedEntityRecognitionData {
+  /** Id of the utterance used for this result */
+  utterance_id: string
+  /** The transcribed utterance */
+  utterance: LiveV2Utterance
+  /** The NER results */
+  results: Array<LiveV2NamedEntityRecognitionResult>
+}
+
+export interface LiveV2ChapterizationSentence {
+  sentence: string
+  start: number
+  end: number
+  words: Array<LiveV2Word>
+}
+
+export interface LiveV2PostChapterizationResult {
+  abstractive_summary?: string
+  extractive_summary?: string
+  summary?: string
+  headline: string
+  gist: string
+  keywords: Array<string>
+  start: number
+  end: number
+  sentences: Array<LiveV2ChapterizationSentence>
+  text: string
+}
+
+export interface LiveV2PostChapterizationMessageData {
+  /** The chapters */
+  results: Array<LiveV2PostChapterizationResult>
 }
 
 export interface LiveV2TranscriptionResult {
@@ -700,6 +768,46 @@ export interface LiveV2InitResponse {
   created_at: string
   /** The websocket url to connect to for sending audio data. The url will contain the temporary token to authenticate the session. */
   url: string
+}
+
+// Job Management Types
+export interface LiveV2Response {
+  /** Id of the job */
+  id: string
+  /** Debug id */
+  request_id: string
+  /** API version */
+  version: number
+  /** "queued": the job has been queued. "processing": the job is being processed. "done": the job has been processed and the result is available. "error": an error occurred during the job's processing. */
+  status: 'queued' | 'processing' | 'done' | 'error'
+  /** Creation date */
+  created_at: string
+  /** Completion date when status is "done" or "error" */
+  completed_at?: string | null
+  /** Custom metadata given in the initial request */
+  custom_metadata?: Record<string, any>
+  /** HTTP status code of the error if status is "error" */
+  error_code?: number | null
+  /** For debugging purposes, send data that could help to identify issues */
+  post_session_metadata?: object
+  kind: 'live'
+  /** The file data you uploaded. Can be null if status is "error" */
+  file?: LiveV2FileResponse | null
+  /** Parameters used for this live transcription. Can be null if status is "error" */
+  request_params?: LiveV2RequestParamsResponse | null
+  /** Live transcription's result when status is "done" */
+  result?: LiveV2TranscriptionResultWithMessages | null
+}
+
+export interface LiveV2ListResponse {
+  /** URL to fetch the first page */
+  first: string
+  /** URL to fetch the current page */
+  current: string
+  /** URL to fetch the next page */
+  next: string | null
+  /** List of live transcriptions */
+  items: Array<LiveV2Response>
 }
 
 // WebSocket Messages Types

--- a/packages/sdk-js/src/v2/prerecorded/generated-types.ts
+++ b/packages/sdk-js/src/v2/prerecorded/generated-types.ts
@@ -451,9 +451,9 @@ export interface PreRecordedV2RequestParamsResponse {
   translation?: boolean
   /** **[Beta]** Translation configuration, if `translation` is enabled */
   translation_config?: PreRecordedV2TranslationConfig
-  /** **[Beta]** Enable summarization for this audio */
+  /** Enable summarization for this audio */
   summarization?: boolean
-  /** **[Beta]** Summarization configuration, if `summarization` is enabled */
+  /** Summarization configuration, if `summarization` is enabled */
   summarization_config?: PreRecordedV2SummarizationConfig
   /** **[Alpha]** Enable named entity recognition for this audio */
   named_entity_recognition?: boolean
@@ -463,9 +463,9 @@ export interface PreRecordedV2RequestParamsResponse {
   custom_spelling_config?: PreRecordedV2CustomSpellingConfig
   /** Enable sentiment analysis for this audio */
   sentiment_analysis?: boolean
-  /** **[Alpha]** Enable audio to llm processing for this audio */
+  /** Enable audio to LLM processing for this audio */
   audio_to_llm?: boolean
-  /** **[Alpha]** Audio to llm configuration, if `audio_to_llm` is enabled */
+  /** Audio to LLM configuration, if `audio_to_llm` is enabled */
   audio_to_llm_config?: PreRecordedV2AudioToLlmListConfig
   /** Enable PII redaction for this audio */
   pii_redaction?: boolean
@@ -650,19 +650,6 @@ export interface PreRecordedV2NamesConsistency {
   results: string
 }
 
-export interface PreRecordedV2SpeakerReidentification {
-  /** The audio intelligence model succeeded to get a valid output */
-  success: boolean
-  /** The audio intelligence model returned an empty value */
-  is_empty: boolean
-  /** Time audio intelligence model took to complete the task */
-  exec_time: number
-  /** `null` if `success` is `true`. Contains the error details of the failed model */
-  error: PreRecordedV2AddonError | null
-  /** If `speaker_reidentification` has been enabled, results of the AI speaker reidentification. */
-  results: string
-}
-
 export interface PreRecordedV2StructuredDataExtraction {
   /** The audio intelligence model succeeded to get a valid output */
   success: boolean
@@ -776,8 +763,6 @@ export interface PreRecordedV2TranscriptionResult {
   named_entity_recognition?: PreRecordedV2NamedEntityRecognition
   /** If `name_consistency` has been enabled, Gladia will improve consistency of the names accross the transcription */
   name_consistency?: PreRecordedV2NamesConsistency
-  /** If `speaker_reidentification` has been enabled, results of the AI speaker reidentification. */
-  speaker_reidentification?: PreRecordedV2SpeakerReidentification
   /** If `structured_data_extraction` has been enabled, structured data extraction results */
   structured_data_extraction?: PreRecordedV2StructuredDataExtraction
   /** If `sentiment_analysis` has been enabled, sentiment analysis of the audio speech transcription */
@@ -832,9 +817,9 @@ export interface PreRecordedV2InitTranscriptionRequest {
   translation?: boolean
   /** **[Beta]** Translation configuration, if `translation` is enabled */
   translation_config?: PreRecordedV2TranslationConfig
-  /** **[Beta]** Enable summarization for this audio */
+  /** Enable summarization for this audio */
   summarization?: boolean
-  /** **[Beta]** Summarization configuration, if `summarization` is enabled */
+  /** Summarization configuration, if `summarization` is enabled */
   summarization_config?: PreRecordedV2SummarizationConfig
   /** **[Alpha]** Enable named entity recognition for this audio */
   named_entity_recognition?: boolean
@@ -844,9 +829,9 @@ export interface PreRecordedV2InitTranscriptionRequest {
   custom_spelling_config?: PreRecordedV2CustomSpellingConfig
   /** Enable sentiment analysis for this audio */
   sentiment_analysis?: boolean
-  /** **[Alpha]** Enable audio to llm processing for this audio */
+  /** Enable audio to LLM processing for this audio */
   audio_to_llm?: boolean
-  /** **[Alpha]** Audio to llm configuration, if `audio_to_llm` is enabled */
+  /** Audio to LLM configuration, if `audio_to_llm` is enabled */
   audio_to_llm_config?: PreRecordedV2AudioToLlmListConfig
   /** Enable PII redaction for this audio */
   pii_redaction?: boolean
@@ -898,4 +883,16 @@ export interface PreRecordedV2Response {
   request_params?: PreRecordedV2RequestParamsResponse | null
   /** Pre-recorded transcription's result when status is "done" */
   result?: PreRecordedV2TranscriptionResult | null
+}
+
+// List Types
+export interface PreRecordedV2ListResponse {
+  /** URL to fetch the first page */
+  first: string
+  /** URL to fetch the current page */
+  current: string
+  /** URL to fetch the next page */
+  next: string | null
+  /** List of pre-recorded transcriptions */
+  items: Array<PreRecordedV2Response>
 }

--- a/packages/sdk-python/src/gladiaio_sdk/__init__.py
+++ b/packages/sdk-python/src/gladiaio_sdk/__init__.py
@@ -7,6 +7,7 @@ from .client import GladiaClient
 from .client_options import (
   GladiaClientOptions,
   HttpRetryOptions,
+  LiveV2Timeouts,
   PreRecordedV2Timeouts,
   WebSocketRetryOptions,
 )
@@ -37,6 +38,7 @@ __all__: list[str] = [
   "TimeoutError",
   "GladiaClientOptions",
   "HttpRetryOptions",
+  "LiveV2Timeouts",
   "PreRecordedV2Timeouts",
   "WebSocketRetryOptions",
   "PreRecordedV2AsyncClient",

--- a/packages/sdk-python/src/gladiaio_sdk/client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/client.py
@@ -9,6 +9,8 @@ from typing import cast, overload
 from gladiaio_sdk.client_options import (
   GladiaClientOptions,
   HttpRetryOptions,
+  LiveV2Timeouts,
+  PreRecordedV2Timeouts,
   Region,
   WebSocketRetryOptions,
 )
@@ -64,6 +66,8 @@ class GladiaClient:
     http_headers: dict[str, str] | None = None,
     http_retry: HttpRetryOptions | None = None,
     http_timeout: float | None = None,
+    prerecorded_timeouts: PreRecordedV2Timeouts | None = None,
+    live_timeouts: LiveV2Timeouts | None = None,
     ws_retry: WebSocketRetryOptions | None = None,
     ws_timeout: float | None = None,
   ) -> None: ...
@@ -87,6 +91,8 @@ class GladiaClient:
     http_headers: dict[str, str] | None = None,
     http_retry: HttpRetryOptions | None = None,
     http_timeout: float | None = None,
+    prerecorded_timeouts: PreRecordedV2Timeouts | None = None,
+    live_timeouts: LiveV2Timeouts | None = None,
     ws_retry: WebSocketRetryOptions | None = None,
     ws_timeout: float | None = None,
   ) -> PreRecordedV2Client: ...
@@ -113,6 +119,8 @@ class GladiaClient:
     http_headers: dict[str, str] | None = None,
     http_retry: HttpRetryOptions | None = None,
     http_timeout: float | None = None,
+    prerecorded_timeouts: PreRecordedV2Timeouts | None = None,
+    live_timeouts: LiveV2Timeouts | None = None,
     ws_retry: WebSocketRetryOptions | None = None,
     ws_timeout: float | None = None,
   ) -> PreRecordedV2AsyncClient: ...
@@ -139,6 +147,8 @@ class GladiaClient:
     http_headers: dict[str, str] | None = None,
     http_retry: HttpRetryOptions | None = None,
     http_timeout: float | None = None,
+    prerecorded_timeouts: PreRecordedV2Timeouts | None = None,
+    live_timeouts: LiveV2Timeouts | None = None,
     ws_retry: WebSocketRetryOptions | None = None,
     ws_timeout: float | None = None,
   ) -> LiveV2Client: ...
@@ -164,6 +174,8 @@ class GladiaClient:
     http_headers: dict[str, str] | None = None,
     http_retry: HttpRetryOptions | None = None,
     http_timeout: float | None = None,
+    prerecorded_timeouts: PreRecordedV2Timeouts | None = None,
+    live_timeouts: LiveV2Timeouts | None = None,
     ws_retry: WebSocketRetryOptions | None = None,
     ws_timeout: float | None = None,
   ) -> LiveV2AsyncClient: ...

--- a/packages/sdk-python/src/gladiaio_sdk/client_options.py
+++ b/packages/sdk-python/src/gladiaio_sdk/client_options.py
@@ -46,6 +46,20 @@ class PreRecordedV2Timeouts:
 
 
 @dataclass(frozen=True, slots=True)
+class LiveV2Timeouts:
+  """HTTP timeouts for live V2 job-management operations (seconds)."""
+
+  get: float = 10
+  delete: float = 60
+  get_file: float = 300
+
+  def __post_init__(self) -> None:
+    for name in ("get", "delete", "get_file"):
+      v = max(0, float(getattr(self, name)))
+      object.__setattr__(self, name, v)
+
+
+@dataclass(frozen=True, slots=True)
 class HttpRetryOptions:
   """Retry behavior for HTTP requests. Retries are not triggered after a timeout."""
 
@@ -95,6 +109,7 @@ class GladiaClientOptions:
   """HTTP request timeout in seconds. Default 10. Retries are not triggered after a timeout."""
   http_timeout: float = DEFAULT_HTTP_TIMEOUT
   prerecorded_timeouts: PreRecordedV2Timeouts = field(default_factory=PreRecordedV2Timeouts)
+  live_timeouts: LiveV2Timeouts = field(default_factory=LiveV2Timeouts)
   ws_retry: WebSocketRetryOptions = WebSocketRetryOptions()
   """WebSocket connection timeout in seconds. Default 10. Retries are not triggered after a timeout."""
   ws_timeout: float = DEFAULT_WS_TIMEOUT

--- a/packages/sdk-python/src/gladiaio_sdk/v2/core.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/core.py
@@ -1,0 +1,38 @@
+"""Shared core logic for V2 job management (live and pre-recorded)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class V2JobCore:
+  """Generic job management helpers parameterized by base path.
+
+  Shared between live (``/v2/live``) and pre-recorded (``/v2/pre-recorded``) clients
+  so that endpoint building, status checks, and error messages stay DRY.
+  """
+
+  def __init__(self, base_path: str, kind: str) -> None:
+    self._base_path = base_path
+    self._kind = kind
+
+  def build_job_endpoint(self, job_id: str) -> str:
+    return f"{self._base_path}/{job_id}"
+
+  def build_job_file_endpoint(self, job_id: str) -> str:
+    return f"{self._base_path}/{job_id}/file"
+
+  def is_job_complete(self, status: str) -> bool:
+    return status in ("done", "error")
+
+  def is_job_successful(self, status: str) -> bool:
+    return status == "done"
+
+  def is_job_failed(self, status: str) -> bool:
+    return status == "error"
+
+  def create_job_error_message(self, job_id: str, error_code: Any) -> str:
+    return f"{self._kind} job {job_id} failed with error code: {error_code}"
+
+  def create_timeout_error_message(self, job_id: str, timeout: float) -> str:
+    return f"{self._kind} job {job_id} did not complete within {timeout}s"

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
@@ -39,6 +39,7 @@ class LiveV2AsyncClient:
       timeout=options.ws_timeout,
     )
 
+    self._options = options
     self._core = V2JobCore(base_path="/v2/live", kind="Live")
 
   def start_session(self, options: LiveV2InitRequest) -> LiveV2AsyncSession:
@@ -58,7 +59,9 @@ class LiveV2AsyncClient:
     from gladiaio_sdk.v2.live.generated_types import LiveV2Response
 
     endpoint = self._core.build_job_endpoint(job_id)
-    resp = await self._http_client.get(endpoint)
+    resp = await self._http_client.get(
+      endpoint, {"request_timeout": self._options.live_timeouts.get}
+    )
     return LiveV2Response.from_dict(resp.json())
 
   async def delete(self, job_id: str) -> bool:
@@ -71,7 +74,9 @@ class LiveV2AsyncClient:
       True if the job was deleted successfully (HTTP 202), False otherwise.
     """
     endpoint = self._core.build_job_endpoint(job_id)
-    resp = await self._http_client.delete(endpoint)
+    resp = await self._http_client.delete(
+      endpoint, {"request_timeout": self._options.live_timeouts.delete}
+    )
     return resp.status_code == 202
 
   async def get_file(self, job_id: str) -> bytes:
@@ -84,5 +89,7 @@ class LiveV2AsyncClient:
       The raw audio file bytes.
     """
     endpoint = self._core.build_job_file_endpoint(job_id)
-    resp = await self._http_client.get(endpoint)
+    resp = await self._http_client.get(
+      endpoint, {"request_timeout": self._options.live_timeouts.get_file}
+    )
     return resp.content

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
@@ -6,16 +6,16 @@ from urllib.parse import urlparse
 
 from gladiaio_sdk.client_options import GladiaClientOptions
 from gladiaio_sdk.network import AsyncHttpClient, WebSocketClient
+from gladiaio_sdk.v2.core import V2JobCore
 from gladiaio_sdk.v2.live.async_session import LiveV2AsyncSession
 
 if TYPE_CHECKING:
-  from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest
+  from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2Response
 
 
 @final
 class LiveV2AsyncClient:
   def __init__(self, options: GladiaClientOptions) -> None:
-    # Create HTTP client
     base_http_url = urlparse(options.api_url)
     base_http_url = base_http_url._replace(scheme=re.sub(r"^ws", "http", base_http_url.scheme))
 
@@ -31,7 +31,6 @@ class LiveV2AsyncClient:
       timeout=options.http_timeout,
     )
 
-    # Create WebSocket client
     base_ws_url = urlparse(options.api_url)
     base_ws_url = base_ws_url._replace(scheme=re.sub(r"^http", "ws", base_ws_url.scheme))
     self._ws_client = WebSocketClient(
@@ -40,7 +39,50 @@ class LiveV2AsyncClient:
       timeout=options.ws_timeout,
     )
 
+    self._core = V2JobCore(base_path="/v2/live", kind="Live")
+
   def start_session(self, options: LiveV2InitRequest) -> LiveV2AsyncSession:
     return LiveV2AsyncSession(
       options=options, http_client=self._http_client, ws_client=self._ws_client
     )
+
+  async def get(self, job_id: str) -> LiveV2Response:
+    """Get a live job by ID.
+
+    Args:
+      job_id: The UUID of the live job.
+
+    Returns:
+      The full job response including status and result if done.
+    """
+    from gladiaio_sdk.v2.live.generated_types import LiveV2Response
+
+    endpoint = self._core.build_job_endpoint(job_id)
+    resp = await self._http_client.get(endpoint)
+    return LiveV2Response.from_dict(resp.json())
+
+  async def delete(self, job_id: str) -> bool:
+    """Delete a live job.
+
+    Args:
+      job_id: The UUID of the live job to delete.
+
+    Returns:
+      True if the job was deleted successfully (HTTP 202), False otherwise.
+    """
+    endpoint = self._core.build_job_endpoint(job_id)
+    resp = await self._http_client.delete(endpoint)
+    return resp.status_code == 202
+
+  async def get_file(self, job_id: str) -> bytes:
+    """Download the audio file for a live job.
+
+    Args:
+      job_id: The UUID of the live job.
+
+    Returns:
+      The raw audio file bytes.
+    """
+    endpoint = self._core.build_job_file_endpoint(job_id)
+    resp = await self._http_client.get(endpoint)
+    return resp.content

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
@@ -6,16 +6,16 @@ from urllib.parse import urlparse
 
 from gladiaio_sdk.client_options import GladiaClientOptions
 from gladiaio_sdk.network import HttpClient, WebSocketClient
+from gladiaio_sdk.v2.core import V2JobCore
 from gladiaio_sdk.v2.live.session import LiveV2Session
 
 if TYPE_CHECKING:
-  from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest
+  from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2Response
 
 
 @final
 class LiveV2Client:
   def __init__(self, options: GladiaClientOptions) -> None:
-    # Create HTTP client
     base_http_url = urlparse(options.api_url)
     base_http_url = base_http_url._replace(scheme=re.sub(r"^ws", "http", base_http_url.scheme))
 
@@ -31,7 +31,6 @@ class LiveV2Client:
       timeout=options.http_timeout,
     )
 
-    # Create WebSocket client
     base_ws_url = urlparse(options.api_url)
     base_ws_url = base_ws_url._replace(scheme=re.sub(r"^http", "ws", base_ws_url.scheme))
     self._ws_client = WebSocketClient(
@@ -40,5 +39,48 @@ class LiveV2Client:
       timeout=options.ws_timeout,
     )
 
+    self._core = V2JobCore(base_path="/v2/live", kind="Live")
+
   def start_session(self, options: LiveV2InitRequest) -> LiveV2Session:
     return LiveV2Session(options=options, http_client=self._http_client, ws_client=self._ws_client)
+
+  def get(self, job_id: str) -> LiveV2Response:
+    """Get a live job by ID.
+
+    Args:
+      job_id: The UUID of the live job.
+
+    Returns:
+      The full job response including status and result if done.
+    """
+    from gladiaio_sdk.v2.live.generated_types import LiveV2Response
+
+    endpoint = self._core.build_job_endpoint(job_id)
+    resp = self._http_client.get(endpoint)
+    return LiveV2Response.from_dict(resp.json())
+
+  def delete(self, job_id: str) -> bool:
+    """Delete a live job.
+
+    Args:
+      job_id: The UUID of the live job to delete.
+
+    Returns:
+      True if the job was deleted successfully (HTTP 202), False otherwise.
+    """
+    endpoint = self._core.build_job_endpoint(job_id)
+    resp = self._http_client.delete(endpoint)
+    return resp.status_code == 202
+
+  def get_file(self, job_id: str) -> bytes:
+    """Download the audio file for a live job.
+
+    Args:
+      job_id: The UUID of the live job.
+
+    Returns:
+      The raw audio file bytes.
+    """
+    endpoint = self._core.build_job_file_endpoint(job_id)
+    resp = self._http_client.get(endpoint)
+    return resp.content

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
@@ -39,6 +39,7 @@ class LiveV2Client:
       timeout=options.ws_timeout,
     )
 
+    self._options = options
     self._core = V2JobCore(base_path="/v2/live", kind="Live")
 
   def start_session(self, options: LiveV2InitRequest) -> LiveV2Session:
@@ -56,7 +57,7 @@ class LiveV2Client:
     from gladiaio_sdk.v2.live.generated_types import LiveV2Response
 
     endpoint = self._core.build_job_endpoint(job_id)
-    resp = self._http_client.get(endpoint)
+    resp = self._http_client.get(endpoint, {"request_timeout": self._options.live_timeouts.get})
     return LiveV2Response.from_dict(resp.json())
 
   def delete(self, job_id: str) -> bool:
@@ -69,7 +70,9 @@ class LiveV2Client:
       True if the job was deleted successfully (HTTP 202), False otherwise.
     """
     endpoint = self._core.build_job_endpoint(job_id)
-    resp = self._http_client.delete(endpoint)
+    resp = self._http_client.delete(
+      endpoint, {"request_timeout": self._options.live_timeouts.delete}
+    )
     return resp.status_code == 202
 
   def get_file(self, job_id: str) -> bytes:
@@ -82,5 +85,7 @@ class LiveV2Client:
       The raw audio file bytes.
     """
     endpoint = self._core.build_job_file_endpoint(job_id)
-    resp = self._http_client.get(endpoint)
+    resp = self._http_client.get(
+      endpoint, {"request_timeout": self._options.live_timeouts.get_file}
+    )
     return resp.content

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/generated_types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/generated_types.py
@@ -392,115 +392,56 @@ class LiveV2CallbackConfig(BaseDataClass):
 
 
 @dataclass(frozen=True, slots=True)
-class LiveV2Error(BaseDataClass):
-  # The error message
-  message: str
+class LiveV2FileResponse(BaseDataClass):
+  # The file id
+  id: str
+  # The name of the uploaded file
+  filename: str | None = None
+  # The link used to download the file if audio_url was used
+  source: str | None = None
+  # Duration of the audio file
+  audio_duration: float | None = None
+  # Number of channels in the audio file
+  number_of_channels: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
-class LiveV2AudioChunkAckData(BaseDataClass):
-  # Range in bytes length of the audio chunk (relative to the whole session)
-  byte_range: list[int]
-  # Range in seconds of the audio chunk (relative to the whole session)
-  time_range: list[float]
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2EndRecordingMessageData(BaseDataClass):
-  # Total audio duration in seconds
-  recording_duration: float
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2Word(BaseDataClass):
-  # Spoken word
-  word: str
-  # Start timestamps in seconds of the spoken word
-  start: float
-  # End timestamps in seconds of the spoken word
-  end: float
-  # Confidence on the transcribed word (1 = 100% confident)
-  confidence: float
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2Utterance(BaseDataClass):
-  # Start timestamp in seconds of this utterance
-  start: float
-  # End timestamp in seconds of this utterance
-  end: float
-  # Confidence on the transcribed utterance (1 = 100% confident)
-  confidence: float
-  # Audio channel of where this utterance has been transcribed from
-  channel: int
-  # List of words of the utterance, split by timestamp
-  words: list[LiveV2Word]
-  # Transcription for this utterance
-  text: str
-  # Spoken language in this utterance
-  language: LiveV2TranscriptionLanguageCode
-  # If `diarization` enabled, speaker identification number
-  speaker: int | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2TranslationData(BaseDataClass):
-  # Id of the utterance used for this result
-  utterance_id: str
-  # The transcribed utterance
-  utterance: LiveV2Utterance
-  # The original language in `iso639-1` or `iso639-2` format depending on the language
-  original_language: LiveV2TranscriptionLanguageCode
-  # The target language in `iso639-1` or `iso639-2` format depending on the language
-  target_language: LiveV2TranslationLanguageCode
-  # The translated utterance
-  translated_utterance: LiveV2Utterance
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2NamedEntityRecognitionResult(BaseDataClass):
-  entity_type: str
-  text: str
-  start: float
-  end: float
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2NamedEntityRecognitionData(BaseDataClass):
-  # Id of the utterance used for this result
-  utterance_id: str
-  # The transcribed utterance
-  utterance: LiveV2Utterance
-  # The NER results
-  results: list[LiveV2NamedEntityRecognitionResult]
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2ChapterizationSentence(BaseDataClass):
-  sentence: str
-  start: float
-  end: float
-  words: list[LiveV2Word]
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2PostChapterizationResult(BaseDataClass):
-  headline: str
-  gist: str
-  keywords: list[str]
-  start: float
-  end: float
-  sentences: list[LiveV2ChapterizationSentence]
-  text: str
-  abstractive_summary: str | None = None
-  extractive_summary: str | None = None
-  summary: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class LiveV2PostChapterizationMessageData(BaseDataClass):
-  # The chapters
-  results: list[LiveV2PostChapterizationResult]
+class LiveV2RequestParamsResponse(BaseDataClass):
+  # The encoding format of the audio stream. Supported formats:
+  # - PCM: 8, 16, 24, and 32 bits
+  # - A-law: 8 bits
+  # - μ-law: 8 bits
+  #
+  # Note: No need to add WAV headers to raw audio as the API supports both formats.
+  encoding: LiveV2Encoding | None = None
+  # The bit depth of the audio stream
+  bit_depth: LiveV2BitDepth | None = None
+  # The sample rate of the audio stream
+  sample_rate: LiveV2SampleRate | None = None
+  # The number of channels of the audio stream
+  channels: int | None = None
+  # The model used to process the audio. "solaria-1" is used by default.
+  model: LiveV2Model | None = None
+  # The endpointing duration in seconds. Endpointing is the duration of silence which will cause
+  # an utterance to be considered as finished
+  endpointing: float | None = None
+  # The maximum duration in seconds without endpointing. If endpointing is not detected after this
+  # duration, current utterance will be considered as finished
+  maximum_duration_without_endpointing: float | None = None
+  # Specify the language configuration
+  language_config: LiveV2LanguageConfig | None = None
+  # Specify the pre-processing configuration
+  pre_processing: LiveV2PreProcessingConfig | None = None
+  # Specify the realtime processing configuration
+  realtime_processing: LiveV2RealtimeProcessingConfig | None = None
+  # Specify the post-processing configuration
+  post_processing: LiveV2PostProcessingConfig | None = None
+  # Specify the websocket messages configuration
+  messages_config: LiveV2MessagesConfig | None = None
+  # If true, messages will be sent to configured url.
+  callback: bool | None = None
+  # Specify the callback configuration
+  callback_config: LiveV2CallbackConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -548,6 +489,38 @@ class LiveV2Subtitle(BaseDataClass):
   format: LiveV2SubtitlesFormat
   # Transcription on the asked subtitle format
   subtitles: str
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2Word(BaseDataClass):
+  # Spoken word
+  word: str
+  # Start timestamps in seconds of the spoken word
+  start: float
+  # End timestamps in seconds of the spoken word
+  end: float
+  # Confidence on the transcribed word (1 = 100% confident)
+  confidence: float
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2Utterance(BaseDataClass):
+  # Start timestamp in seconds of this utterance
+  start: float
+  # End timestamp in seconds of this utterance
+  end: float
+  # Confidence on the transcribed utterance (1 = 100% confident)
+  confidence: float
+  # Audio channel of where this utterance has been transcribed from
+  channel: int
+  # List of words of the utterance, split by timestamp
+  words: list[LiveV2Word]
+  # Transcription for this utterance
+  text: str
+  # Spoken language in this utterance
+  language: LiveV2TranscriptionLanguageCode
+  # If `diarization` enabled, speaker identification number
+  speaker: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -609,6 +582,14 @@ class LiveV2Summarization(BaseDataClass):
 
 
 @dataclass(frozen=True, slots=True)
+class LiveV2NamedEntityRecognitionResult(BaseDataClass):
+  entity_type: str
+  text: str
+  start: float
+  end: float
+
+
+@dataclass(frozen=True, slots=True)
 class LiveV2NamedEntityRecognition(BaseDataClass):
   # The audio intelligence model succeeded to get a valid output
   success: bool
@@ -650,6 +631,99 @@ class LiveV2Chapterization(BaseDataClass):
   results: dict[str, Any]
   # `null` if `success` is `true`. Contains the error details of the failed model
   error: LiveV2AddonError | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2TranscriptionResultWithMessages(BaseDataClass):
+  # Metadata for the given transcription & audio file
+  metadata: LiveV2TranscriptionMetadata
+  # Transcription of the audio speech
+  transcription: LiveV2Transcription | None = None
+  # If `translation` has been enabled, translation of the audio speech transcription
+  translation: LiveV2Translation | None = None
+  # If `summarization` has been enabled, summarization of the audio speech transcription
+  summarization: LiveV2Summarization | None = None
+  # If `named_entity_recognition` has been enabled, the detected entities
+  named_entity_recognition: LiveV2NamedEntityRecognition | None = None
+  # If `sentiment_analysis` has been enabled, sentiment analysis of the audio speech transcription
+  sentiment_analysis: LiveV2SentimentAnalysis | None = None
+  # If `chapterization` has been enabled, will generate chapters name for different parts of the
+  # given audio.
+  chapterization: LiveV2Chapterization | None = None
+  # Real-Time messages sent by the server during the live transcription
+  messages: list[str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2Error(BaseDataClass):
+  # The error message
+  message: str
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2AudioChunkAckData(BaseDataClass):
+  # Range in bytes length of the audio chunk (relative to the whole session)
+  byte_range: list[int]
+  # Range in seconds of the audio chunk (relative to the whole session)
+  time_range: list[float]
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2EndRecordingMessageData(BaseDataClass):
+  # Total audio duration in seconds
+  recording_duration: float
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2TranslationData(BaseDataClass):
+  # Id of the utterance used for this result
+  utterance_id: str
+  # The transcribed utterance
+  utterance: LiveV2Utterance
+  # The original language in `iso639-1` or `iso639-2` format depending on the language
+  original_language: LiveV2TranscriptionLanguageCode
+  # The target language in `iso639-1` or `iso639-2` format depending on the language
+  target_language: LiveV2TranslationLanguageCode
+  # The translated utterance
+  translated_utterance: LiveV2Utterance
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2NamedEntityRecognitionData(BaseDataClass):
+  # Id of the utterance used for this result
+  utterance_id: str
+  # The transcribed utterance
+  utterance: LiveV2Utterance
+  # The NER results
+  results: list[LiveV2NamedEntityRecognitionResult]
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2ChapterizationSentence(BaseDataClass):
+  sentence: str
+  start: float
+  end: float
+  words: list[LiveV2Word]
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2PostChapterizationResult(BaseDataClass):
+  headline: str
+  gist: str
+  keywords: list[str]
+  start: float
+  end: float
+  sentences: list[LiveV2ChapterizationSentence]
+  text: str
+  abstractive_summary: str | None = None
+  extractive_summary: str | None = None
+  summary: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2PostChapterizationMessageData(BaseDataClass):
+  # The chapters
+  results: list[LiveV2PostChapterizationResult]
 
 
 @dataclass(frozen=True, slots=True)
@@ -780,6 +854,50 @@ class LiveV2InitResponse(BaseDataClass):
   # The websocket url to connect to for sending audio data. The url will contain the temporary
   # token to authenticate the session.
   url: str
+
+
+# Job Management Types
+@dataclass(frozen=True, slots=True)
+class LiveV2Response(BaseDataClass):
+  # Id of the job
+  id: str
+  # Debug id
+  request_id: str
+  # API version
+  version: int
+  # "queued": the job has been queued. "processing": the job is being processed. "done": the job
+  # has been processed and the result is available. "error": an error occurred during the job's
+  # processing.
+  status: Literal["queued", "processing", "done", "error"]
+  # Creation date
+  created_at: str
+  kind: Literal["live"]
+  # For debugging purposes, send data that could help to identify issues
+  post_session_metadata: dict[str, Any] | None = None
+  # Completion date when status is "done" or "error"
+  completed_at: str | None = None
+  # Custom metadata given in the initial request
+  custom_metadata: dict[str, Any] | None = None
+  # HTTP status code of the error if status is "error"
+  error_code: int | None = None
+  # The file data you uploaded. Can be null if status is "error"
+  file: LiveV2FileResponse | None = None
+  # Parameters used for this live transcription. Can be null if status is "error"
+  request_params: LiveV2RequestParamsResponse | None = None
+  # Live transcription's result when status is "done"
+  result: LiveV2TranscriptionResultWithMessages | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveV2ListResponse(BaseDataClass):
+  # URL to fetch the first page
+  first: str
+  # URL to fetch the current page
+  current: str
+  # List of live transcriptions
+  items: list[LiveV2Response]
+  # URL to fetch the next page
+  next: str | None = None
 
 
 # WebSocket Messages Types

--- a/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/core.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/core.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any, BinaryIO, Protocol, cast
 from urllib.parse import urlparse
 
+from gladiaio_sdk.v2.core import V2JobCore
+
 from .generated_types import (
   BaseDataClass,
   PreRecordedV2AudioToLlmListConfig,
@@ -108,11 +110,15 @@ class HttpClientProtocol(Protocol):
   def delete(self, url: str, **kwargs: Any) -> Any: ...
 
 
-class PreRecordedV2Core:
+class PreRecordedV2Core(V2JobCore):
   """Core business logic shared between sync and async pre-recorded clients.
 
-  This class contains all the pure business logic without any I/O operations.
+  Extends :class:`V2JobCore` with pre-recorded-specific helpers (file upload,
+  create body preparation).
   """
+
+  def __init__(self) -> None:
+    super().__init__(base_path="/v2/pre-recorded", kind="Pre-recorded")
 
   @staticmethod
   def is_url(path: str) -> bool:
@@ -183,89 +189,3 @@ class PreRecordedV2Core:
     if isinstance(options, dict):
       return options
     return options.to_dict()
-
-  @staticmethod
-  def build_job_endpoint(job_id: str) -> str:
-    """Build the endpoint URL for a specific job.
-
-    Args:
-      job_id: The UUID of the transcription job.
-
-    Returns:
-      The endpoint path.
-    """
-    return f"/v2/pre-recorded/{job_id}"
-
-  @staticmethod
-  def build_job_file_endpoint(job_id: str) -> str:
-    """Build the endpoint URL for downloading job audio file.
-
-    Args:
-      job_id: The UUID of the transcription job.
-
-    Returns:
-      The endpoint path.
-    """
-    return f"/v2/pre-recorded/{job_id}/file"
-
-  @staticmethod
-  def is_job_complete(status: str) -> bool:
-    """Check if a job has completed (successfully or with error).
-
-    Args:
-      status: The job status string.
-
-    Returns:
-      True if job is in terminal state.
-    """
-    return status in ("done", "error")
-
-  @staticmethod
-  def is_job_successful(status: str) -> bool:
-    """Check if a job completed successfully.
-
-    Args:
-      status: The job status string.
-
-    Returns:
-      True if job is done.
-    """
-    return status == "done"
-
-  @staticmethod
-  def is_job_failed(status: str) -> bool:
-    """Check if a job failed.
-
-    Args:
-      status: The job status string.
-
-    Returns:
-      True if job errored.
-    """
-    return status == "error"
-
-  @staticmethod
-  def create_job_error_message(job_id: str, error_code: Any) -> str:
-    """Create an error message for a failed job.
-
-    Args:
-      job_id: The UUID of the transcription job.
-      error_code: The error code from the job response.
-
-    Returns:
-      Formatted error message.
-    """
-    return f"Pre-recorded job {job_id} failed with error code: {error_code}"
-
-  @staticmethod
-  def create_timeout_error_message(job_id: str, timeout: float) -> str:
-    """Create an error message for a timeout.
-
-    Args:
-      job_id: The UUID of the transcription job.
-      timeout: The timeout duration in seconds.
-
-    Returns:
-      Formatted timeout message.
-    """
-    return f"Pre-recorded job {job_id} did not complete within {timeout}s"

--- a/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/generated_types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/prerecorded/generated_types.py
@@ -503,9 +503,9 @@ class PreRecordedV2RequestParamsResponse(BaseDataClass):
   translation: bool | None = None
   # **[Beta]** Translation configuration, if `translation` is enabled
   translation_config: PreRecordedV2TranslationConfig | None = None
-  # **[Beta]** Enable summarization for this audio
+  # Enable summarization for this audio
   summarization: bool | None = None
-  # **[Beta]** Summarization configuration, if `summarization` is enabled
+  # Summarization configuration, if `summarization` is enabled
   summarization_config: PreRecordedV2SummarizationConfig | None = None
   # **[Alpha]** Enable named entity recognition for this audio
   named_entity_recognition: bool | None = None
@@ -515,9 +515,9 @@ class PreRecordedV2RequestParamsResponse(BaseDataClass):
   custom_spelling_config: PreRecordedV2CustomSpellingConfig | None = None
   # Enable sentiment analysis for this audio
   sentiment_analysis: bool | None = None
-  # **[Alpha]** Enable audio to llm processing for this audio
+  # Enable audio to LLM processing for this audio
   audio_to_llm: bool | None = None
-  # **[Alpha]** Audio to llm configuration, if `audio_to_llm` is enabled
+  # Audio to LLM configuration, if `audio_to_llm` is enabled
   audio_to_llm_config: PreRecordedV2AudioToLlmListConfig | None = None
   # Enable PII redaction for this audio
   pii_redaction: bool | None = None
@@ -717,20 +717,6 @@ class PreRecordedV2NamesConsistency(BaseDataClass):
 
 
 @dataclass(frozen=True, slots=True)
-class PreRecordedV2SpeakerReidentification(BaseDataClass):
-  # The audio intelligence model succeeded to get a valid output
-  success: bool
-  # The audio intelligence model returned an empty value
-  is_empty: bool
-  # Time audio intelligence model took to complete the task
-  exec_time: float
-  # If `speaker_reidentification` has been enabled, results of the AI speaker reidentification.
-  results: str
-  # `null` if `success` is `true`. Contains the error details of the failed model
-  error: PreRecordedV2AddonError | None = None
-
-
-@dataclass(frozen=True, slots=True)
 class PreRecordedV2StructuredDataExtraction(BaseDataClass):
   # The audio intelligence model succeeded to get a valid output
   success: bool
@@ -856,8 +842,6 @@ class PreRecordedV2TranscriptionResult(BaseDataClass):
   # If `name_consistency` has been enabled, Gladia will improve consistency of the names accross
   # the transcription
   name_consistency: PreRecordedV2NamesConsistency | None = None
-  # If `speaker_reidentification` has been enabled, results of the AI speaker reidentification.
-  speaker_reidentification: PreRecordedV2SpeakerReidentification | None = None
   # If `structured_data_extraction` has been enabled, structured data extraction results
   structured_data_extraction: PreRecordedV2StructuredDataExtraction | None = None
   # If `sentiment_analysis` has been enabled, sentiment analysis of the audio speech transcription
@@ -924,9 +908,9 @@ class PreRecordedV2InitTranscriptionRequest(BaseDataClass):
   translation: bool | None = None
   # **[Beta]** Translation configuration, if `translation` is enabled
   translation_config: PreRecordedV2TranslationConfig | None = None
-  # **[Beta]** Enable summarization for this audio
+  # Enable summarization for this audio
   summarization: bool | None = None
-  # **[Beta]** Summarization configuration, if `summarization` is enabled
+  # Summarization configuration, if `summarization` is enabled
   summarization_config: PreRecordedV2SummarizationConfig | None = None
   # **[Alpha]** Enable named entity recognition for this audio
   named_entity_recognition: bool | None = None
@@ -936,9 +920,9 @@ class PreRecordedV2InitTranscriptionRequest(BaseDataClass):
   custom_spelling_config: PreRecordedV2CustomSpellingConfig | None = None
   # Enable sentiment analysis for this audio
   sentiment_analysis: bool | None = None
-  # **[Alpha]** Enable audio to llm processing for this audio
+  # Enable audio to LLM processing for this audio
   audio_to_llm: bool | None = None
-  # **[Alpha]** Audio to llm configuration, if `audio_to_llm` is enabled
+  # Audio to LLM configuration, if `audio_to_llm` is enabled
   audio_to_llm_config: PreRecordedV2AudioToLlmListConfig | None = None
   # Enable PII redaction for this audio
   pii_redaction: bool | None = None
@@ -992,3 +976,16 @@ class PreRecordedV2Response(BaseDataClass):
   request_params: PreRecordedV2RequestParamsResponse | None = None
   # Pre-recorded transcription's result when status is "done"
   result: PreRecordedV2TranscriptionResult | None = None
+
+
+# List Types
+@dataclass(frozen=True, slots=True)
+class PreRecordedV2ListResponse(BaseDataClass):
+  # URL to fetch the first page
+  first: str
+  # URL to fetch the current page
+  current: str
+  # List of pre-recorded transcriptions
+  items: list[PreRecordedV2Response]
+  # URL to fetch the next page
+  next: str | None = None


### PR DESCRIPTION
## Summary

- Adds get, delete, and getFile methods to the live V2 client in both the JavaScript and Python SDKs (sync and async), enabling retrieval, deletion, and audio file download for live jobs via the /v2/live/{jobId} endpoints.
- Introduces a shared V2JobCore helper in the Python SDK to build job endpoints consistently, extracted from the existing prerecorded client logic.
- Extends the code generator to process and emit StreamingResponse and ListStreamingResponse schema types (and ListPreRecordedResponse for prerecorded), updating generated types for both live and prerecorded in JS and Python.
- Adds end-to-end tests covering the new get, delete, and getFile methods for live V2 in both JS (CJS/ESM) and Python.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job management for Live V2: get job metadata, delete jobs (202 semantics), and download recorded audio files.
  * List support for Pre-recorded V2 responses and new Live/Pre-recorded list endpoints.
  * SDK timeout configs for Live V2 operations.

* **Tests**
  * End-to-end tests added for Live V2 job management across Node.js (CJS/ESM) and Python.

* **Refactor**
  * Pre-recorded core reworked to share common job-core logic; speaker reidentification output removed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gladiaio/sdk/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->