### PR TITLE
fix: declare eventemitter3 as SDK runtime dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,7 +86,7 @@
       "name": "@gladiaio/sdk",
       "version": "1.0.4",
       "dependencies": {
-        "eventemitter3": ">=5",
+        "eventemitter3": "^5.0.0",
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.6",

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,9 @@
     "packages/sdk-js": {
       "name": "@gladiaio/sdk",
       "version": "1.0.4",
+      "dependencies": {
+        "eventemitter3": ">=5",
+      },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.6",
         "@types/node": "^20.19.19",
@@ -92,7 +95,6 @@
         "tsdown": "^0.15.6",
       },
       "peerDependencies": {
-        "eventemitter3": ">=5",
         "undici": ">=5",
         "ws": "5.2.4 || 6.2.3 || 7.5.10 || >=8.8",
       },

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -29,7 +29,7 @@
     "build:watch": "tsdown --watch"
   },
   "dependencies": {
-    "eventemitter3": ">=5"
+    "eventemitter3": "^5.0.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.6",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -28,6 +28,9 @@
     "build": "tsdown",
     "build:watch": "tsdown --watch"
   },
+  "dependencies": {
+    "eventemitter3": ">=5"
+  },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.6",
     "@types/node": "^20.19.19",
@@ -35,7 +38,6 @@
     "tsdown": "^0.15.6"
   },
   "peerDependencies": {
-    "eventemitter3": ">=5",
     "ws": "5.2.4 || 6.2.3 || 7.5.10 || >=8.8",
     "undici": ">=5"
   },


### PR DESCRIPTION
## Summary

- moves `eventemitter3` from peer dependencies to runtime dependencies for the published `@gladiaio/sdk` package
- keeps `ws` and `undici` as optional peers
- updates the Bun lock workspace metadata for the same dependency move

Fixes #30.

## Reproduction

A clean Yarn 1 install of the published package currently warns about the unmet peer and then fails at SDK import time because `dist/v2/live/session.js` imports `eventemitter3` internally:

```sh
tmp=$(mktemp -d)
cd "$tmp"
corepack yarn init -y >/dev/null 2>&1
corepack yarn add @gladiaio/sdk@1.0.4 --ignore-scripts --silent
node --input-type=module -e "import('@gladiaio/sdk')"
```

Observed before this patch:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eventemitter3' imported from .../node_modules/@gladiaio/sdk/dist/v2/live/session.js
```

## Validation

- `npm run build --workspaces=false` from `packages/sdk-js` passed
- `npm pack --ignore-scripts --json --workspaces=false` from `packages/sdk-js` passed
- clean Yarn 1 install of the patched tarball successfully imported `@gladiaio/sdk`
- patched tarball package metadata includes `dependencies.eventemitter3 = >=5`
- `git diff --check` passed
- `node -e "JSON.parse(require('fs').readFileSync('packages/sdk-js/package.json','utf8'))"` passed

Note: `./node_modules/.bin/nx run sdk-js:test --skipNxCache` currently runs but fails two unrelated `src/client.test.ts` assertions because those tests instantiate a Gladia API host without `apiKey` or proxy `apiUrl`. The dependency change is covered by the packed clean-install smoke above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency declarations to include `eventemitter3` as a direct dependency, removing the requirement for consumers to supply it separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->