### PR TITLE
fix(live-v2): chunk audio buffer on reconnect to avoid oversized ws frames (GLA-3052)

### DIFF
--- a/packages/sdk-js/src/v2/live/session.ts
+++ b/packages/sdk-js/src/v2/live/session.ts
@@ -207,7 +207,10 @@ export class LiveV2Session {
 
     this.webSocketSession.onopen = ({ connection }) => {
       if (this.audioBuffer?.byteLength) {
-        webSocketSession.send(this.audioBuffer)
+        const MAX_CHUNK = 512 * 1024 // 512 KiB, well below the 1 MiB server frame limit
+        for (let offset = 0; offset < this.audioBuffer.byteLength; offset += MAX_CHUNK) {
+          webSocketSession.send(this.audioBuffer.subarray(offset, offset + MAX_CHUNK))
+        }
       }
       if (this.status === 'ending') {
         webSocketSession.send(JSON.stringify({ type: 'stop_recording' }))

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/async_session.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/async_session.py
@@ -35,6 +35,7 @@ from .generated_types import (
 
 EventCallback = Callable[..., Any]
 
+_MAX_RESUME_CHUNK_BYTES = 512 * 1024  # 512 KiB, well below the 1 MiB server frame limit
 
 LiveV2SessionStatus = Literal["starting", "started", "connecting", "connected", "ending", "ended"]
 
@@ -174,7 +175,8 @@ class LiveV2AsyncSession:
         return
 
       if self._audio_buffer and len(self._audio_buffer):
-        ws.send(self._audio_buffer)
+        for i in range(0, len(self._audio_buffer), _MAX_RESUME_CHUNK_BYTES):
+          ws.send(self._audio_buffer[i : i + _MAX_RESUME_CHUNK_BYTES])
 
       if self._status == "ending":
         ws.send(json.dumps({"type": "stop_recording"}))

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/session.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/session.py
@@ -36,6 +36,7 @@ from .generated_types import (
 
 EventCallback = Callable[..., Any]
 
+_MAX_RESUME_CHUNK_BYTES = 512 * 1024  # 512 KiB, well below the 1 MiB server frame limit
 
 LiveV2SessionStatus = Literal["starting", "started", "connecting", "connected", "ending", "ended"]
 
@@ -185,7 +186,8 @@ class LiveV2Session:
         pending_stop = self._pending_stop
       if buffered and len(buffered):
         with contextlib.suppress(Exception):
-          ws.send(buffered)
+          for i in range(0, len(buffered), _MAX_RESUME_CHUNK_BYTES):
+            ws.send(buffered[i : i + _MAX_RESUME_CHUNK_BYTES])
       if pending_stop:
         with self._state_lock:
           self._pending_stop = False


### PR DESCRIPTION
## Summary

Fixes [GLA-3052](https://linear.app/gladia/issue/GLA-3052/mediatech-python-live-v2-sdk-reconnect-sends-oversized-websocket-frame) — reported by Mediatech (Antony Simonneau-Krol).

On Live V2 WebSocket **reconnect**, the SDK was re-sending the entire unacknowledged `_audio_buffer` in a single frame. When the buffer exceeded the server's **1 MiB frame limit**, the connection was closed with **CloseCode 1009**. After repeated failures the server returned **HTTP 403**, making the session unrecoverable (observed in production after the 3h session limit closed the socket: ~1.8 MB frame sent).

### Changes

- Split the resume resend into **512 KiB chunks** (well below the 1 MiB limit) on reconnect in:
  - `packages/sdk-python/src/gladiaio_sdk/v2/live/session.py` (sync client)
  - `packages/sdk-python/src/gladiaio_sdk/v2/live/async_session.py` (async client)
  - `packages/sdk-js/src/v2/live/session.ts` (JS client)

### Before / After

**Before** (`_on_open`):
```python
ws.send(buffered)  # could be >1 MiB → CloseCode 1009
```

**After**:
```python
for i in range(0, len(buffered), _MAX_RESUME_CHUNK_BYTES):  # 512 KiB
    ws.send(buffered[i : i + _MAX_RESUME_CHUNK_BYTES])
```

## Test plan

- [ ] Simulate a reconnect with >1 MiB of unacknowledged audio and verify no CloseCode 1009 is received
- [ ] Verify transcription resumes correctly after reconnect with large buffer
- [ ] Verify JS client behaves identically

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffered audio handling across JavaScript and Python SDKs. When resuming sessions with buffered audio, data is now transmitted in fixed-size chunks instead of a single large message, reducing transmission errors and improving session reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->