### PR TITLE
[FEA-1646]: add connect session function without initiating live session for js and python

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,7 +84,7 @@
     },
     "packages/sdk-js": {
       "name": "@gladiaio/sdk",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "@tsconfig/node20": "^20.1.6",
         "@types/node": "^20.19.19",

--- a/e2e/e2e-node-cjs/test/live_v2_job_management.test.cjs
+++ b/e2e/e2e-node-cjs/test/live_v2_job_management.test.cjs
@@ -37,6 +37,26 @@ async function runLiveSession() {
   return jobId
 }
 
+/**
+ * Poll until the live job reaches a terminal status (done or error).
+ * The API only allows deletion once post-processing has finished.
+ */
+async function waitForTerminalJobStatus(
+  client,
+  jobId,
+  { intervalMs = 1000, timeoutMs = 60_000 } = {}
+) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const result = await client.get(jobId)
+    if (result.status === 'done' || result.status === 'error') {
+      return result
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error(`Timed out waiting for job ${jobId} to reach terminal status`)
+}
+
 test('get: returns live job metadata after session ends', async () => {
   const jobId = await runLiveSession()
   const client = new GladiaClient().liveV2()
@@ -62,6 +82,7 @@ test('getFile: returns audio bytes with RIFF header', async () => {
 test('delete: returns true on success (HTTP 202)', async () => {
   const jobId = await runLiveSession()
   const client = new GladiaClient().liveV2()
+  await waitForTerminalJobStatus(client, jobId)
   const deleted = await client.delete(jobId)
   assert.strictEqual(deleted, true)
 })

--- a/e2e/e2e-node-esm/test/live_v2_job_management.test.ts
+++ b/e2e/e2e-node-esm/test/live_v2_job_management.test.ts
@@ -37,6 +37,26 @@ async function runLiveSession(): Promise<string> {
   return jobId
 }
 
+/**
+ * Poll until the live job reaches a terminal status (done or error).
+ * The API only allows deletion once post-processing has finished.
+ */
+async function waitForTerminalJobStatus(
+  client: ReturnType<GladiaClient['liveV2']>,
+  jobId: string,
+  { intervalMs = 1000, timeoutMs = 60_000 }: { intervalMs?: number; timeoutMs?: number } = {}
+): Promise<LiveV2Response> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const result = await client.get(jobId)
+    if (result.status === 'done' || result.status === 'error') {
+      return result
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error(`Timed out waiting for job ${jobId} to reach terminal status`)
+}
+
 test('get: returns live job metadata after session ends', async () => {
   const jobId = await runLiveSession()
   const client = new GladiaClient().liveV2()
@@ -62,6 +82,7 @@ test('getFile: returns audio bytes with RIFF header', async () => {
 test('delete: returns true on success (HTTP 202)', async () => {
   const jobId = await runLiveSession()
   const client = new GladiaClient().liveV2()
+  await waitForTerminalJobStatus(client, jobId)
   const deleted = await client.delete(jobId)
   assert.strictEqual(deleted, true)
 })

--- a/e2e/e2e-python/tests/test_live_v2_job_management.py
+++ b/e2e/e2e-python/tests/test_live_v2_job_management.py
@@ -5,6 +5,7 @@ the session to end, then exercises the HTTP job-management method.
 """
 
 import asyncio
+import time
 
 import pytest
 from gladiaio_sdk import GladiaClient, HttpError
@@ -51,6 +52,26 @@ async def _run_live_session() -> str:
   return job_id
 
 
+async def _wait_for_terminal_job_status(
+  client,
+  job_id: str,
+  *,
+  interval_s: float = 1.0,
+  timeout_s: float = 60.0,
+):
+  """Poll until the live job reaches a terminal status (done or error).
+
+  The API only allows deletion once post-processing has finished.
+  """
+  deadline = time.monotonic() + timeout_s
+  while time.monotonic() < deadline:
+    result = await client.get(job_id)
+    if result.status in ("done", "error"):
+      return result
+    await asyncio.sleep(interval_s)
+  raise TimeoutError(f"Timed out waiting for job {job_id} to reach terminal status")
+
+
 @pytest.mark.asyncio
 async def test_get():
   """get returns live job metadata after session ends."""
@@ -78,6 +99,7 @@ async def test_delete():
   """delete returns True when job is correctly removed (HTTP 202)."""
   job_id = await _run_live_session()
   client = GladiaClient().live_v2_async()
+  await _wait_for_terminal_job_status(client, job_id)
   deleted = await client.delete(job_id)
   assert deleted is True
 

--- a/packages/sdk-js/src/client.test.ts
+++ b/packages/sdk-js/src/client.test.ts
@@ -13,7 +13,10 @@ describe('GladiaClient', () => {
   })
 
   it('merges default headers and appends SDK version when providing user headers at construction', () => {
-    const gladiaClient = new GladiaClient({ httpHeaders: { 'x-custom': 'abc' } })
+    const gladiaClient = new GladiaClient({
+      apiKey: 'test-key',
+      httpHeaders: { 'x-custom': 'abc' },
+    })
     gladiaClient.liveV2()
     const calls = liveV2Spy.mock.calls
     expect(calls.length).toBeGreaterThan(0)
@@ -23,7 +26,10 @@ describe('GladiaClient', () => {
   })
 
   it('appends SDK version to any provided X-GLADIA-VERSION value', () => {
-    const gladiaClient = new GladiaClient({ httpHeaders: { 'X-GLADIA-VERSION': 'MyApp/1.2.3' } })
+    const gladiaClient = new GladiaClient({
+      apiKey: 'test-key',
+      httpHeaders: { 'X-GLADIA-VERSION': 'MyApp/1.2.3' },
+    })
     gladiaClient.liveV2()
     const calls = liveV2Spy.mock.calls
     expect(calls.length).toBeGreaterThan(0)

--- a/packages/sdk-js/src/v2/live/client.ts
+++ b/packages/sdk-js/src/v2/live/client.ts
@@ -1,8 +1,9 @@
 import { InternalGladiaClientOptions } from '../../internal_types.js'
 import { HttpClient } from '../../network/httpClient.js'
 import { WebSocketClient } from '../../network/wsClient.js'
-import type { LiveV2InitRequest, LiveV2Response } from './generated-types.js'
+import type { LiveV2InitRequest, LiveV2InitResponse, LiveV2Response } from './generated-types.js'
 import { LiveV2Session } from './session.js'
+import type { LiveV2ConnectSessionOptions } from './types.js'
 
 /**
  * Client used to interact with Gladia Live Speech-To-Text API.
@@ -36,6 +37,24 @@ export class LiveV2Client {
   startSession(options: LiveV2InitRequest): LiveV2Session {
     return new LiveV2Session({
       options,
+      httpClient: this.httpClient,
+      webSocketClient: this.webSocketClient,
+    })
+  }
+
+  /**
+   * Connect to an existing live session using its WebSocket URL and session ID.
+   * Skips session initialization and connects directly to the WebSocket.
+   */
+  connectSession(connectOptions: LiveV2ConnectSessionOptions): LiveV2Session {
+    const existingSession: LiveV2InitResponse = {
+      id: connectOptions.id,
+      url: connectOptions.url,
+      created_at: connectOptions.created_at ?? '',
+    }
+    return new LiveV2Session({
+      options: { messages_config: connectOptions.messages_config },
+      existingSession,
       httpClient: this.httpClient,
       webSocketClient: this.webSocketClient,
     })

--- a/packages/sdk-js/src/v2/live/session.test.ts
+++ b/packages/sdk-js/src/v2/live/session.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HttpClient } from '../../network/httpClient.js'
+import { WebSocketClient, WS_STATES } from '../../network/wsClient.js'
+import { LiveV2Session } from './session.js'
+
+type MockWebSocketSession = {
+  readyState: number
+  onconnecting: ((event: { connection: number; attempt: number }) => void) | null
+  onopen: ((event: { connection: number; attempt: number }) => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+  onclose: ((event: { code: number; reason: string }) => void) | null
+  onerror: ((error: Error) => void) | null
+  send: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+}
+
+describe('LiveV2Session connectSession', () => {
+  let mockHttpPost: ReturnType<typeof vi.fn>
+  let mockCreateSession: ReturnType<typeof vi.fn>
+  let mockWsSession: MockWebSocketSession
+  let httpClient: HttpClient
+  let webSocketClient: WebSocketClient
+
+  beforeEach(() => {
+    mockHttpPost = vi.fn().mockResolvedValue({
+      id: 'created-session-id',
+      url: 'wss://api.gladia.io/v2/live/ws?token=created',
+      created_at: '2026-06-25T09:00:00Z',
+    })
+
+    mockWsSession = {
+      readyState: WS_STATES.CONNECTING,
+      onconnecting: null,
+      onopen: null,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      send: vi.fn(),
+      close: vi.fn(),
+    }
+
+    mockCreateSession = vi.fn().mockReturnValue(mockWsSession)
+
+    httpClient = { post: mockHttpPost } as unknown as HttpClient
+    webSocketClient = { createSession: mockCreateSession } as unknown as WebSocketClient
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function tick(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  it('skips HTTP init and connects to the provided WebSocket URL', async () => {
+    const existingSession = {
+      id: 'session-123',
+      url: 'wss://api.gladia.io/v2/live/ws?token=abc',
+      created_at: '2026-06-25T10:00:00Z',
+    }
+
+    const startedSpy = vi.fn()
+    const connectedSpy = vi.fn()
+
+    const session = new LiveV2Session({
+      options: {},
+      existingSession,
+      httpClient,
+      webSocketClient,
+    })
+
+    session.on('started', startedSpy)
+    session.once('connected', connectedSpy)
+
+    await tick()
+
+    expect(mockHttpPost).not.toHaveBeenCalled()
+    expect(mockCreateSession).toHaveBeenCalledWith(existingSession.url)
+    expect(startedSpy).toHaveBeenCalledWith(existingSession)
+    expect(session.sessionId).toBe('session-123')
+
+    mockWsSession.onopen?.({ connection: 1, attempt: 1 })
+    expect(connectedSpy).toHaveBeenCalledWith({ attempt: 1 })
+    expect(session.status).toBe('connected')
+  })
+
+  it('emits a synthetic start_session lifecycle message when configured', async () => {
+    const existingSession = {
+      id: 'session-123',
+      url: 'wss://api.gladia.io/v2/live/ws?token=abc',
+      created_at: '2026-06-25T10:00:00Z',
+    }
+
+    const messageSpy = vi.fn()
+
+    const session = new LiveV2Session({
+      options: {
+        messages_config: {
+          receive_lifecycle_events: true,
+        },
+      },
+      existingSession,
+      httpClient,
+      webSocketClient,
+    })
+
+    session.on('message', messageSpy)
+
+    await tick()
+
+    expect(messageSpy).toHaveBeenCalledWith({
+      type: 'start_session',
+      session_id: existingSession.id,
+      created_at: existingSession.created_at,
+    })
+  })
+
+  it('still calls HTTP init for startSession flow', async () => {
+    const startedSpy = vi.fn()
+
+    const session = new LiveV2Session({
+      options: {
+        encoding: 'wav/pcm',
+        sample_rate: 16000,
+      },
+      httpClient,
+      webSocketClient,
+    })
+
+    session.on('started', startedSpy)
+
+    await tick()
+
+    expect(mockHttpPost).toHaveBeenCalledWith('/v2/live', expect.objectContaining({
+      body: expect.stringContaining('"sample_rate":16000'),
+    }))
+    expect(mockCreateSession).toHaveBeenCalledWith('wss://api.gladia.io/v2/live/ws?token=created')
+    expect(startedSpy).toHaveBeenCalledWith({
+      id: 'created-session-id',
+      url: 'wss://api.gladia.io/v2/live/ws?token=created',
+      created_at: '2026-06-25T09:00:00Z',
+    })
+    expect(session.sessionId).toBe('created-session-id')
+  })
+})

--- a/packages/sdk-js/src/v2/live/session.test.ts
+++ b/packages/sdk-js/src/v2/live/session.test.ts
@@ -132,9 +132,12 @@ describe('LiveV2Session connectSession', () => {
 
     await tick()
 
-    expect(mockHttpPost).toHaveBeenCalledWith('/v2/live', expect.objectContaining({
-      body: expect.stringContaining('"sample_rate":16000'),
-    }))
+    expect(mockHttpPost).toHaveBeenCalledWith(
+      '/v2/live',
+      expect.objectContaining({
+        body: expect.stringContaining('"sample_rate":16000'),
+      })
+    )
     expect(mockCreateSession).toHaveBeenCalledWith('wss://api.gladia.io/v2/live/ws?token=created')
     expect(startedSpy).toHaveBeenCalledWith({
       id: 'created-session-id',

--- a/packages/sdk-js/src/v2/live/session.ts
+++ b/packages/sdk-js/src/v2/live/session.ts
@@ -38,10 +38,12 @@ export class LiveV2Session {
 
   constructor({
     options,
+    existingSession,
     httpClient,
     webSocketClient,
   }: {
     options: LiveV2InitRequest
+    existingSession?: LiveV2InitResponse
     httpClient: HttpClient
     webSocketClient: WebSocketClient
   }) {
@@ -50,7 +52,9 @@ export class LiveV2Session {
     this.webSocketClient = webSocketClient
     this.abortController = new AbortController()
 
-    this.initSessionPromise = this.initSession()
+    this.initSessionPromise = existingSession
+      ? Promise.resolve(existingSession)
+      : this.initSession()
     this.startSession()
   }
 

--- a/packages/sdk-js/src/v2/live/types.ts
+++ b/packages/sdk-js/src/v2/live/types.ts
@@ -1,3 +1,5 @@
+import type { LiveV2MessagesConfig } from './generated-types.js'
+
 export type LiveV2SessionStatus =
   | 'starting'
   | 'started'
@@ -5,3 +7,10 @@ export type LiveV2SessionStatus =
   | 'connected'
   | 'ending'
   | 'ended'
+
+export interface LiveV2ConnectSessionOptions {
+  id: string
+  url: string
+  created_at?: string
+  messages_config?: LiveV2MessagesConfig
+}

--- a/packages/sdk-js/src/version.ts
+++ b/packages/sdk-js/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build. Do not edit manually.
-export const SDK_VERSION = '1.0.4' as const
+export const SDK_VERSION = '1.0.5' as const

--- a/packages/sdk-js/src/version.ts
+++ b/packages/sdk-js/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during build. Do not edit manually.
-export const SDK_VERSION = '1.0.5' as const
+export const SDK_VERSION = '1.0.4' as const

--- a/packages/sdk-python/src/gladiaio_sdk/__init__.py
+++ b/packages/sdk-python/src/gladiaio_sdk/__init__.py
@@ -18,6 +18,7 @@ from .v2.live.client import LiveV2Client
 from .v2.live.types import (
   LiveV2ConnectedMessage,
   LiveV2ConnectingMessage,
+  LiveV2ConnectSessionOptions,
   LiveV2EndedMessage,
   LiveV2EndingMessage,
 )
@@ -31,6 +32,7 @@ __all__: list[str] = [
   "LiveV2AsyncClient",
   "LiveV2AsyncSession",
   "LiveV2ConnectingMessage",
+  "LiveV2ConnectSessionOptions",
   "LiveV2ConnectedMessage",
   "LiveV2EndedMessage",
   "LiveV2EndingMessage",

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/async_client.py
@@ -8,6 +8,7 @@ from gladiaio_sdk.client_options import GladiaClientOptions
 from gladiaio_sdk.network import AsyncHttpClient, WebSocketClient
 from gladiaio_sdk.v2.core import V2JobCore
 from gladiaio_sdk.v2.live.async_session import LiveV2AsyncSession
+from gladiaio_sdk.v2.live.types import LiveV2ConnectSessionOptions
 
 if TYPE_CHECKING:
   from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2Response
@@ -45,6 +46,26 @@ class LiveV2AsyncClient:
   def start_session(self, options: LiveV2InitRequest) -> LiveV2AsyncSession:
     return LiveV2AsyncSession(
       options=options, http_client=self._http_client, ws_client=self._ws_client
+    )
+
+  def connect_session(self, options: LiveV2ConnectSessionOptions) -> LiveV2AsyncSession:
+    """Connect to an existing live session using its WebSocket URL and session ID.
+
+    Skips session initialization and connects directly to the WebSocket.
+    """
+    from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2InitResponse
+
+    existing_session = LiveV2InitResponse(
+      id=options.id,
+      url=options.url,
+      created_at=options.created_at or "",
+    )
+    init_options = LiveV2InitRequest(messages_config=options.messages_config)
+    return LiveV2AsyncSession(
+      options=init_options,
+      http_client=self._http_client,
+      ws_client=self._ws_client,
+      existing_session=existing_session,
     )
 
   async def get(self, job_id: str) -> LiveV2Response:

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/async_session.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/async_session.py
@@ -59,6 +59,7 @@ class LiveV2AsyncSession(LiveV2SessionEventsMixin):
     options: LiveV2InitRequest,
     http_client: AsyncHttpClient,
     ws_client: WebSocketClient,
+    existing_session: LiveV2InitResponse | None = None,
   ) -> None:
     self._options = options
     self._http_client = http_client
@@ -67,7 +68,7 @@ class LiveV2AsyncSession(LiveV2SessionEventsMixin):
     self._abort = asyncio.Event()
     self._event_emitter = AsyncIOEventEmitter()
     self._status: LiveV2SessionStatus = "starting"
-    self._init_session_response: LiveV2InitResponse | None = None
+    self._init_session_response: LiveV2InitResponse | None = existing_session
 
     self._ws: AsyncWebSocketSession | None = None
     self._connect_ws_task: asyncio.Task[None] | None = None
@@ -75,8 +76,12 @@ class LiveV2AsyncSession(LiveV2SessionEventsMixin):
     self._audio_buffer: bytes = bytes([])
     self._bytes_sent = 0
 
-    # Kick off session creation
-    self._init_session_task = asyncio.create_task(self._init_session())
+    if existing_session:
+      init_task: asyncio.Future[LiveV2InitResponse] = asyncio.get_running_loop().create_future()
+      init_task.set_result(existing_session)
+      self._init_session_task = init_task
+    else:
+      self._init_session_task = asyncio.create_task(self._init_session())
     self._start_session_task = asyncio.create_task(self._start_session())
 
   # Public API

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/client.py
@@ -8,6 +8,7 @@ from gladiaio_sdk.client_options import GladiaClientOptions
 from gladiaio_sdk.network import HttpClient, WebSocketClient
 from gladiaio_sdk.v2.core import V2JobCore
 from gladiaio_sdk.v2.live.session import LiveV2Session
+from gladiaio_sdk.v2.live.types import LiveV2ConnectSessionOptions
 
 if TYPE_CHECKING:
   from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2Response
@@ -44,6 +45,26 @@ class LiveV2Client:
 
   def start_session(self, options: LiveV2InitRequest) -> LiveV2Session:
     return LiveV2Session(options=options, http_client=self._http_client, ws_client=self._ws_client)
+
+  def connect_session(self, options: LiveV2ConnectSessionOptions) -> LiveV2Session:
+    """Connect to an existing live session using its WebSocket URL and session ID.
+
+    Skips session initialization and connects directly to the WebSocket.
+    """
+    from gladiaio_sdk.v2.live.generated_types import LiveV2InitRequest, LiveV2InitResponse
+
+    existing_session = LiveV2InitResponse(
+      id=options.id,
+      url=options.url,
+      created_at=options.created_at or "",
+    )
+    init_options = LiveV2InitRequest(messages_config=options.messages_config)
+    return LiveV2Session(
+      options=init_options,
+      http_client=self._http_client,
+      ws_client=self._ws_client,
+      existing_session=existing_session,
+    )
 
   def get(self, job_id: str) -> LiveV2Response:
     """Get a live job by ID.

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/session.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/session.py
@@ -60,10 +60,12 @@ class LiveV2Session(LiveV2SessionEventsMixin):
     options: LiveV2InitRequest,
     http_client: HttpClient,
     ws_client: WebSocketClient,
+    existing_session: LiveV2InitResponse | None = None,
   ) -> None:
     self._options = options
     self._http_client = http_client
     self._ws_client = ws_client
+    self._existing_session = existing_session
 
     self._event_emitter = EventEmitter()
     self._status: LiveV2SessionStatus = "starting"
@@ -224,9 +226,10 @@ class LiveV2Session(LiveV2SessionEventsMixin):
 
   def _lifecycle_worker(self) -> None:
     try:
-      # 1) HTTP init
-      self._init_session_response = self._init_session()
-      # 2) Emit started and connect WS
+      if self._existing_session:
+        self._init_session_response = self._existing_session
+      else:
+        self._init_session_response = self._init_session()
       self._start_session()
       # 3) Keep thread alive until stop/end to let join() wait for session end
       while not self._ws_stop.is_set() and self._status != "ended":

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/types.py
@@ -1,8 +1,20 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+  from .generated_types import LiveV2MessagesConfig
 
 LiveV2SessionStatus = Literal["starting", "started", "connecting", "connected", "ending", "ended"]
 
+
+@dataclass(frozen=True, slots=True)
+class LiveV2ConnectSessionOptions:
+  id: str
+  url: str
+  created_at: str | None = None
+  messages_config: LiveV2MessagesConfig | None = None
 
 @dataclass(frozen=True, slots=True)
 class LiveV2ConnectingMessage:

--- a/packages/sdk-python/src/gladiaio_sdk/v2/live/types.py
+++ b/packages/sdk-python/src/gladiaio_sdk/v2/live/types.py
@@ -16,6 +16,7 @@ class LiveV2ConnectSessionOptions:
   created_at: str | None = None
   messages_config: LiveV2MessagesConfig | None = None
 
+
 @dataclass(frozen=True, slots=True)
 class LiveV2ConnectingMessage:
   attempt: int

--- a/packages/sdk-python/tests/v2/live/test_connect_session.py
+++ b/packages/sdk-python/tests/v2/live/test_connect_session.py
@@ -1,0 +1,222 @@
+"""Tests for Live V2 connect_session (reconnect to an existing session)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from gladiaio_sdk.client_options import GladiaClientOptions, WebSocketRetryOptions
+from gladiaio_sdk.network import WS_STATES
+from gladiaio_sdk.v2.live.async_client import LiveV2AsyncClient
+from gladiaio_sdk.v2.live.client import LiveV2Client
+from gladiaio_sdk.v2.live.generated_types import (
+  LiveV2InitRequest,
+  LiveV2MessagesConfig,
+)
+from gladiaio_sdk.v2.live.types import LiveV2ConnectSessionOptions
+
+
+class FakeHttpClient:
+  def __init__(self) -> None:
+    self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+  def post(self, url: str, **kwargs: Any) -> Any:
+    self.post_calls.append((url, kwargs))
+
+    class Response:
+      content = json.dumps(
+        {
+          "id": "created-session-id",
+          "url": "wss://api.gladia.io/v2/live/ws?token=created",
+          "created_at": "2026-06-25T09:00:00Z",
+        }
+      ).encode()
+
+    return Response()
+
+
+class FakeAsyncHttpClient(FakeHttpClient):
+  async def post(self, url: str, **kwargs: Any) -> Any:
+    return super().post(url, **kwargs)
+
+
+class FakeWebSocketSession:
+  def __init__(self, url: str) -> None:
+    self.url = url
+    self.ready_state = WS_STATES.CONNECTING
+    self.onconnecting: Any = None
+    self.onopen: Any = None
+    self.onmessage: Any = None
+    self.onclose: Any = None
+    self.onerror: Any = None
+    self.sent: list[Any] = []
+
+  def send(self, data: Any) -> None:
+    self.sent.append(data)
+
+  def close(self, code: int = 1000, reason: str = "") -> None:
+    self.ready_state = WS_STATES.CLOSED
+    if self.onclose:
+      self.onclose({"code": code, "reason": reason})
+
+  def start(self) -> None:
+    self.trigger_open()
+
+  def trigger_open(self) -> None:
+    if self.onconnecting:
+      self.onconnecting({"attempt": 1})
+    self.ready_state = WS_STATES.OPEN
+    if self.onopen:
+      self.onopen({"attempt": 1})
+
+
+class FakeWebSocketClient:
+  def __init__(self) -> None:
+    self.created_urls: list[str] = []
+    self.sessions: list[FakeWebSocketSession] = []
+
+  def create_session(self, url: str) -> FakeWebSocketSession:
+    self.created_urls.append(url)
+    session = FakeWebSocketSession(url)
+    self.sessions.append(session)
+    return session
+
+  def create_async_session(self, url: str) -> FakeWebSocketSession:
+    return self.create_session(url)
+
+
+def _client_options() -> GladiaClientOptions:
+  return GladiaClientOptions(
+    api_url="https://api.gladia.io",
+    ws_retry=WebSocketRetryOptions(max_attempts_per_connection=0, max_connections=0),
+  )
+
+
+def _wait_for(predicate: Callable[[], bool], timeout: float = 2.0) -> bool:
+  deadline = time.time() + timeout
+  while time.time() < deadline:
+    if predicate():
+      return True
+    time.sleep(0.01)
+  return False
+
+
+def test_connect_session_skips_http_init_and_connects(monkeypatch):
+  http_client = FakeHttpClient()
+  ws_client = FakeWebSocketClient()
+
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.client.HttpClient",
+    lambda **kwargs: http_client,
+  )
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.client.WebSocketClient",
+    lambda **kwargs: ws_client,
+  )
+
+  client = LiveV2Client(_client_options())
+
+  session = client.connect_session(
+    LiveV2ConnectSessionOptions(
+      id="session-123",
+      url="wss://api.gladia.io/v2/live/ws?token=abc",
+      created_at="2026-06-25T10:00:00Z",
+      messages_config=LiveV2MessagesConfig(receive_lifecycle_events=True),
+    )
+  )
+
+  assert _wait_for(lambda: session.session_id == "session-123")
+  assert _wait_for(lambda: session.status == "connected")
+
+  assert http_client.post_calls == []
+  assert ws_client.created_urls == ["wss://api.gladia.io/v2/live/ws?token=abc"]
+
+  session.end_session()
+  assert session.join(timeout=2)
+
+
+def test_start_session_still_calls_http_init(monkeypatch):
+  http_client = FakeHttpClient()
+  ws_client = FakeWebSocketClient()
+
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.client.HttpClient",
+    lambda **kwargs: http_client,
+  )
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.client.WebSocketClient",
+    lambda **kwargs: ws_client,
+  )
+
+  client = LiveV2Client(_client_options())
+  session = client.start_session(LiveV2InitRequest(sample_rate=16000))
+
+  assert _wait_for(lambda: session.session_id == "created-session-id")
+  assert _wait_for(lambda: session.status == "connected")
+
+  assert len(http_client.post_calls) == 1
+  assert http_client.post_calls[0][0] == "/v2/live"
+  assert http_client.post_calls[0][1]["json"]["sample_rate"] == 16000
+  assert ws_client.created_urls == ["wss://api.gladia.io/v2/live/ws?token=created"]
+
+  session.end_session()
+  assert session.join(timeout=2)
+
+
+async def _run_async_connect_session_test(
+  http_client: FakeAsyncHttpClient,
+  ws_client: FakeWebSocketClient,
+) -> None:
+  client = LiveV2AsyncClient(_client_options())
+  session = client.connect_session(
+    LiveV2ConnectSessionOptions(
+      id="session-456",
+      url="wss://api.gladia.io/v2/live/ws?token=def",
+      created_at="2026-06-25T11:00:00Z",
+    )
+  )
+
+  deadline = time.time() + 2
+  while time.time() < deadline:
+    if session.session_id == "session-456" and len(ws_client.sessions) == 1:
+      break
+    await asyncio.sleep(0.01)
+  else:
+    pytest.fail("session was not initialized")
+
+  ws_client.sessions[0].trigger_open()
+
+  deadline = time.time() + 2
+  while time.time() < deadline:
+    if session.status == "connected":
+      break
+    await asyncio.sleep(0.01)
+  else:
+    pytest.fail("session did not reach connected status")
+
+  assert http_client.post_calls == []
+  assert ws_client.created_urls == ["wss://api.gladia.io/v2/live/ws?token=def"]
+  assert await session.get_session_id() == "session-456"
+
+  session.end_session()
+
+
+def test_async_connect_session_skips_http_init_and_connects(monkeypatch):
+  http_client = FakeAsyncHttpClient()
+  ws_client = FakeWebSocketClient()
+
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.async_client.AsyncHttpClient",
+    lambda **kwargs: http_client,
+  )
+  monkeypatch.setattr(
+    "gladiaio_sdk.v2.live.async_client.WebSocketClient",
+    lambda **kwargs: ws_client,
+  )
+
+  asyncio.run(_run_async_connect_session_test(http_client, ws_client))


### PR DESCRIPTION
## Quick Summary

This PR is to add a new function: 'Connect Session' which is basically a 'init session' but without to define the api key.
for connect session we need the client, id and url of the websocket and that's it

(We added for python and js)
 
## how to use it

const gladiaClient = new GladiaClient({ apiKey: 'your-api-key' })   -> create client

// get the infos from backend

const sessionId = 'abc-123-...'
const websocketUrl = 'wss://api.gladia.io/v2/live/...?token=...'
const createdAt = '2026-06-25T10:00:00Z' // optional

// based on the info, we can connect with 
const liveSession = gladiaClient.liveV2().connectSession({
  id: sessionId,
  url: websocketUrl,
  created_at: createdAt, // optional — only needed if you want lifecycle messages
})
// rest is same behavior as initsession




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to connect to an existing live session without starting a new one.
  * This is available in both JavaScript and Python SDKs, for sync and async clients.
  * Live session options can now include session details and lifecycle message settings.

* **Bug Fixes**
  * Improved live job deletion flow so deletion happens only after jobs reach a terminal state.
  * Updated SDK version to `1.0.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->